### PR TITLE
Hotfix -> Removed <button> wrapping content in FigureCard component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Lana B2C MicroApp Libs Changelog
 
+## v.4.0.1 - 2020-03-20
+ - Removed button inside FigureCard component and onclick/link props
+
 ## v.4.0.0 - 2020-03-20
  - Add FigureCard component
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Shared custom libraries for building µapps.",
   "repository": {
     "type": "git",

--- a/src/buttons/FigureCard/FigureCard.test.js
+++ b/src/buttons/FigureCard/FigureCard.test.js
@@ -8,13 +8,11 @@ describe('FigureCard unit test:', () => {
 		className: '',
 		meta: 'Meta text',
 		title: 'Title text',
-		imageSrc: 'myImage.png',
-		link: '/redirect/to/here',
-		onClick: () => {},
+		imageSrc: 'myImage.png'
 	}
 	it('Should set imageSrc as background for figure-card-test-image:', () => {
 		const mockedClick = jest.fn()
-		const wrapper = mount(<FigureCard {...defaultProps} onClick={mockedClick} />)
+		const wrapper = mount(<FigureCard {...defaultProps} />)
 		const figureStyles = wrapper.find('[data-testid="figure-card-test-image"]').prop('style')
 		expect(figureStyles).toHaveProperty('backgroundImage', "url('myImage.png')")
 	})

--- a/src/buttons/FigureCard/FigureCard.test.js
+++ b/src/buttons/FigureCard/FigureCard.test.js
@@ -18,20 +18,4 @@ describe('FigureCard unit test:', () => {
 		const figureStyles = wrapper.find('[data-testid="figure-card-test-image"]').prop('style')
 		expect(figureStyles).toHaveProperty('backgroundImage', "url('myImage.png')")
 	})
-
-	it('Should trigger onClick:', () => {
-		const mockedClick = jest.fn()
-		const wrapper = mount(<FigureCard {...defaultProps} onClick={mockedClick} />)
-		const cta = wrapper.find('[data-testid="figure-card-test-cta"]')
-		cta.simulate('click')
-		expect(mockedClick).toHaveBeenCalled()
-	})
-
-	it('Should trigger onClick passing link as param:', () => {
-		const mockedClick = jest.fn()
-		const wrapper = mount(<FigureCard {...defaultProps} onClick={mockedClick} />)
-		const cta = wrapper.find('[data-testid="figure-card-test-cta"]')
-		cta.simulate('click')
-		expect(mockedClick).toHaveBeenCalledWith(defaultProps.link)
-	})
 })

--- a/src/buttons/FigureCard/index.jsx
+++ b/src/buttons/FigureCard/index.jsx
@@ -2,13 +2,12 @@ import CSS from './styles.css'
 import PropTypes from 'prop-types'
 import Text from '../../typography/Text'
 
-export default function FigureCard ({ dataTestId, size, className, meta, imageSrc, title, link, onClick }) {
+export default function FigureCard ({ dataTestId, size, className, meta, imageSrc, title }) {
 	const backgroundStyle = {
 		backgroundImage: `url('${imageSrc}')`,
 	}
 
 	return (
-		<button data-testid={`${dataTestId}-cta`} onClick={() => onClick(link)} className={CSS.platforms}>
 			<figure className={`${CSS.FigureCard} ${className} ${(size && CSS[size]) || ''}`}>
 				<div data-testid={`${dataTestId}-image`} style={backgroundStyle} />
 				<figcaption>
@@ -16,7 +15,6 @@ export default function FigureCard ({ dataTestId, size, className, meta, imageSr
 					{meta && <Text dataTestId={`${dataTestId}-meta`} type="txt-xsmall">{meta}</Text>}
 				</figcaption>
 			</figure>
-		</button>
 	)
 }
 
@@ -26,9 +24,7 @@ FigureCard.defaultProps = {
 	className: '',
 	meta: '',
 	title: '',
-	imageSrc: '',
-	link: '',
-	onClick: () => {},
+	imageSrc: ''
 }
 
 FigureCard.propTypes = {

--- a/src/buttons/FigureCard/index.jsx
+++ b/src/buttons/FigureCard/index.jsx
@@ -34,6 +34,4 @@ FigureCard.propTypes = {
 	meta: PropTypes.string,
 	title: PropTypes.string,
 	imageSrc: PropTypes.string,
-	link: PropTypes.string,
-	onClick: PropTypes.func,
 }


### PR DESCRIPTION
## Description
(My mistake ✋). FigureCard does not need to have a "button" element and trigger onClick. This should be handled outside by parent component.

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
