### PR TITLE
Add missing flex property for scroll height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Lana B2C MicroApp Libs Changelog
 
+## v.4.0.3 - 2020-04-29
+ - Scrolling height adjustments for short lists.
+ 
 ## v.4.0.2 - 2020-04-28
  - Better scrolling.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Shared custom libraries for building µapps.",
   "repository": {
     "type": "git",

--- a/src/structure/Scroll/styles.css
+++ b/src/structure/Scroll/styles.css
@@ -1,3 +1,4 @@
 .scroll {
 	overflow-y: auto;
+	flex-grow: 1;
 }


### PR DESCRIPTION
## Description
Missed `flex-grow` property to ensure height required is applied for scroll component.


### Problem sample

![image](https://user-images.githubusercontent.com/61735887/80566745-ee856800-89f3-11ea-9d9d-fc2c0d30d61f.png)


## Checks
- [x] Requires lib version update

## Versioning impact
- [x] **PATCH** backwards-compatible bug fixes.



![](https://media.giphy.com/media/lF5bH6enH9F1m/giphy.gif)
