### PR TITLE
Update FormField and its derived components to support focus()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "6.0.0",
+  "version": "6.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/BankAccountNumberInputField/BankAccountNumberInputField.js
+++ b/src/components/BankAccountNumberInputField/BankAccountNumberInputField.js
@@ -26,6 +26,7 @@ const props = {
   name: String,
   disabled: Boolean,
   readonly: Boolean,
+  startFocused: Boolean,
 };
 
 const data = function () {
@@ -89,6 +90,9 @@ const methods = {
     };
     this.$emit('input', this.inputValue);
     this.$emit('change', payload);
+  },
+  focus() {
+    this.$refs.field.focus();
   },
   onFocus(event) {
     this.$emit('focus', event);

--- a/src/components/BankAccountNumberInputField/BankAccountNumberInputField.vue
+++ b/src/components/BankAccountNumberInputField/BankAccountNumberInputField.vue
@@ -1,10 +1,12 @@
 <template>
-  <FormField v-model="inputValue"
+  <FormField ref="field"
+             v-model="inputValue"
              :data-test-id="dataTestId"
              :label="label"
              :error-label="errorLabelToShow"
              :disabled="disabled"
              :readonly="readonly"
+             :start-focused="startFocused"
              type="tel"
              :name="name"
              :max-length="maxLength"

--- a/src/components/DateField/DateField.js
+++ b/src/components/DateField/DateField.js
@@ -35,6 +35,7 @@ const props = {
   autoformat: Boolean,
   datePicker: Boolean,
   readonly: Boolean,
+  startFocused: Boolean,
   disabled: Boolean,
 };
 
@@ -98,6 +99,9 @@ const methods = {
     this.$emit('input', this.inputValue);
     this.$emit('change', this.formFieldFormattedDateText);
     this.$emit('validate', validationPayload);
+  },
+  focus() {
+    this.$refs.field.focus();
   },
   onFocus(event) {
     this.$emit('focus', event);

--- a/src/components/DateField/DateField.vue
+++ b/src/components/DateField/DateField.vue
@@ -1,6 +1,7 @@
 <template>
   <div data-testid="date-field-wrapper" class="calendar-wrapper">
     <FormField :id="formFieldId"
+               ref="field"
                v-model="inputValue"
                :name="formFieldName"
                :data-test-id="dataTestId"
@@ -10,6 +11,7 @@
                :readonly="readonly"
                :disabled="disabled"
                :max-length="maxLength"
+               :start-focused="startFocused"
                @blur="onBlur"
                @focus="onFocus"
     />

--- a/src/components/FormField/FormField.js
+++ b/src/components/FormField/FormField.js
@@ -64,6 +64,9 @@ const methods = {
     this.toggleFocus();
     this.$emit('blur', event);
   },
+  focus() {
+    this.$refs.input.focus();
+  },
 };
 
 const watch = {

--- a/src/components/PhoneNumberField/PhoneNumberField.js
+++ b/src/components/PhoneNumberField/PhoneNumberField.js
@@ -1,4 +1,5 @@
 import { AsYouType, getCountryCallingCode, getCountries } from 'libphonenumber-js/custom';
+import { parsePhoneNumberFromString } from 'libphonenumber-js';
 
 import FormField from '../FormField/FormField.vue';
 import TextParagraph from '../TextParagraph/TextParagraph.vue';
@@ -67,6 +68,14 @@ const methods = {
   },
   focus() {
     this.$refs.field.focus();
+  },
+  isPhoneNumberValid() {
+    try {
+      const parsedNumber = parsePhoneNumberFromString(this.formattedPhoneNumber, this.countryCode);
+      return parsedNumber.isValid();
+    } catch (parsingError) {
+      return false;
+    }
   },
 };
 

--- a/src/components/PhoneNumberField/PhoneNumberField.js
+++ b/src/components/PhoneNumberField/PhoneNumberField.js
@@ -1,5 +1,4 @@
 import { AsYouType, getCountryCallingCode, getCountries } from 'libphonenumber-js/custom';
-import { parsePhoneNumberFromString } from 'libphonenumber-js';
 
 import FormField from '../FormField/FormField.vue';
 import TextParagraph from '../TextParagraph/TextParagraph.vue';
@@ -70,12 +69,10 @@ const methods = {
     this.$refs.field.focus();
   },
   isPhoneNumberValid() {
-    try {
-      const parsedNumber = parsePhoneNumberFromString(this.formattedPhoneNumber, this.countryCode);
-      return parsedNumber.isValid();
-    } catch (parsingError) {
-      return false;
-    }
+    const asYouType = new AsYouType(this.countryCode, phoneNumberMetadata);
+    asYouType.input(this.inputValue);
+    const result = asYouType.isPossible();
+    return result;
   },
 };
 

--- a/src/components/PhoneNumberField/PhoneNumberField.js
+++ b/src/components/PhoneNumberField/PhoneNumberField.js
@@ -26,6 +26,7 @@ const props = {
     validator(value) { return availableCountryCodes.includes(value); },
   },
   hideCountryCode: Boolean,
+  startFocused: Boolean,
   label: String,
   errorLabel: String,
   id: String,
@@ -63,6 +64,9 @@ const methods = {
   },
   onBlur(event) {
     this.$emit('blur', event);
+  },
+  focus() {
+    this.$refs.field.focus();
   },
 };
 

--- a/src/components/PhoneNumberField/PhoneNumberField.stories.js
+++ b/src/components/PhoneNumberField/PhoneNumberField.stories.js
@@ -39,12 +39,18 @@ const defaultExample = () => ({
   data() {
     return {
       value: '',
+      isValid: false,
     };
   },
   methods: {
     onBlur: action('Blur!'),
     onFocus: action('Focus!'),
     onInput: action('Changed!'),
+  },
+  watch: {
+    value() {
+      this.isValid = this.$refs.field.isPhoneNumberValid();
+    },
   },
   template: `
     <div style="margin: 10px 50px 10px 50px;">
@@ -66,6 +72,7 @@ const defaultExample = () => ({
       <div style="display: flex; flex-direction: column; width: 100%;">
         <div style="width: 500px">
           <PhoneNumberField v-model="value"
+                            ref="field"
                             :country-code="countryCode"
                             :hide-country-code="hideCountryCode"
                             :disabled="disabled"
@@ -77,9 +84,9 @@ const defaultExample = () => ({
                             @input="onInput"
           />
           <br>
-          <div>
-            Bound value: {{ value }}
-          </div>
+          <div>Bound value: {{ value }}</div>
+          <br>
+          <div>Is Valid?: {{ isValid }}</div>
         </div>
       </div>
     </div>

--- a/src/components/PhoneNumberField/PhoneNumberField.stories.js
+++ b/src/components/PhoneNumberField/PhoneNumberField.stories.js
@@ -18,7 +18,7 @@ const defaultExample = () => ({
   },
   props: {
     label: {
-      default: text('Label', 'Example Text Field'),
+      default: text('Label', 'Example Phone Field'),
     },
     errorLabel: {
       default: text('Error Label', ''),

--- a/src/components/PhoneNumberField/PhoneNumberField.vue
+++ b/src/components/PhoneNumberField/PhoneNumberField.vue
@@ -1,5 +1,6 @@
 <template>
   <FormField :id="id"
+             ref="field"
              v-model="inputValue"
              class="field"
              :class="{ filled: !hideCountryCode }"
@@ -10,6 +11,7 @@
              :show-prefix="!hideCountryCode"
              :disabled="disabled"
              :readonly="readonly"
+             :start-focused="startFocused"
              :data-test-id="dataTestId"
              @blur="onBlur"
              @focus="onFocus"

--- a/src/components/TextField/TextField.js
+++ b/src/components/TextField/TextField.js
@@ -47,6 +47,9 @@ const methods = {
   emitInputEvent() {
     this.$emit('input', this.inputValue);
   },
+  focus() {
+    this.$refs.field.focus();
+  },
   onFocus(event) {
     this.$emit('focus', event);
   },

--- a/src/components/TextField/TextField.vue
+++ b/src/components/TextField/TextField.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="wrapper">
-    <FormField v-model="inputValue"
+    <FormField ref="field"
+               v-model="inputValue"
                :data-test-id="dataTestId"
                :label="label"
                :type="type"


### PR DESCRIPTION
## Description

  * Update `FormField` and its derived components to support focus()
  * Ensured that all `FormField`-derived components also support the `startFocused` prop.
  * Added `isPhoneNumberValid` helper method to the `PhoneNumberField` component and updated its Storybook story to showcase that.

## Testing
  
  * `npm run lint`: **PASS**
  * `npm run test`: **PASS**
  * Local Storybook Testing: **PASS**

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
