### PR TITLE
Improve BankAccountNumberInputField (MX-Merino #662)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/BankAccountNumberInputField/BankAccountNumberInputField.js
+++ b/src/components/BankAccountNumberInputField/BankAccountNumberInputField.js
@@ -100,6 +100,12 @@ const methods = {
   onBlur(event) {
     this.$emit('blur', event);
   },
+  onPaste(event) {
+    const rawPasteValue = (event.clipboardData || window.clipboardData).getData('text');
+    const sanitizedValue = (rawPasteValue && rawPasteValue.replace(allSpacesRegexp, ''));
+    this.inputValue = sanitizedValue;
+    event.preventDefault();
+  },
   updateInputValueWithFormatting() {
     if (this.accountNumberWithoutSpaces.length > this.bankAccountTemplate.length) { return; }
     this.inputValue = this.parsedAccountNumber;

--- a/src/components/BankAccountNumberInputField/BankAccountNumberInputField.vue
+++ b/src/components/BankAccountNumberInputField/BankAccountNumberInputField.vue
@@ -12,6 +12,7 @@
              :max-length="maxLength"
              @blur="onBlur"
              @focus="onFocus"
+             @paste="onPaste"
   />
 </template>
 

--- a/src/components/FormField/FormField.js
+++ b/src/components/FormField/FormField.js
@@ -64,6 +64,9 @@ const methods = {
     this.toggleFocus();
     this.$emit('blur', event);
   },
+  onPaste(event) {
+    this.$emit('paste', event);
+  },
   focus() {
     this.$refs.input.focus();
   },

--- a/src/components/FormField/FormField.vue
+++ b/src/components/FormField/FormField.vue
@@ -18,6 +18,7 @@
            :disabled="disabled"
            @focus="onFocus"
            @blur="onBlur"
+           @paste="onPaste"
     >
   </label>
 </template>


### PR DESCRIPTION
## Description

  * Updated the `FormField` component to emit a `paste` event.
  * Updated the `BankAccountNumberInputField` component to silently remove spaces from pasted values (for mx-merino #662).

**NOTE**: I will be making another PR soon for applying these changes to the old React version of this UI Library (required for applying this improvement to `mx-merino`)

## Testing

  * `npm run lint`: **PASS**
  * `npm run test`: **PASS**
  * Tested locally with Storybook

## Screenshots/Captures

  * **Broken** (when trying to paste a value of: `1 2 34 56 789123666678`):
    ![Screencap - Broken](https://user-images.githubusercontent.com/6749993/82990822-0e14ae00-9ffd-11ea-92b5-ac9dc9047a9b.gif)

  * **Fixed** (when trying to paste a value of: `1 2 34 56 789123666678`):
    ![Screencap - Fixed](https://user-images.githubusercontent.com/6749993/82990864-1c62ca00-9ffd-11ea-8bf0-d54645f093a3.gif)

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
