### PR TITLE
SVG Icon size fixes after updating to the latest b2c-mapp-ui-assets version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "6.0.2",
+  "version": "6.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1545,9 +1545,9 @@
       }
     },
     "@lana/b2c-mapp-ui-assets": {
-      "version": "4.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@lana/b2c-mapp-ui-assets/4.0.2/38454965ef33bb69141cca01f125747c091f286c8ddb61d22268803a695d2baa",
-      "integrity": "sha512-kPtmTR7Zn4r5mjuVNMnpGJdwtYPTbxQ5d6di89RwfWniREE+UDDmwuT7Bu7c8if0iTLizZ93RsxMLMtAM4Iozw==",
+      "version": "4.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@lana/b2c-mapp-ui-assets/4.1.0/5621cb1cd09ee345781d767d72208c81f1e41c0e4d4498cf769364b8d017a688",
+      "integrity": "sha512-svF1R90RHRpx+YCHbqjwDbRJ7U5zmch8/C9b0G8H9JlYQfgeATvGrS5MbZEC9IuIeS6dhkZzD7prJd9CjQ665A==",
       "requires": {
         "core-js": "^3.6.4",
         "vue": "^2.6.11"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.9.6",
-    "@lana/b2c-mapp-ui-assets": "^4.0.2",
+    "@lana/b2c-mapp-ui-assets": "^4.1.0",
     "core-js": "^3.6.4",
     "fast-async": "^6.3.8",
     "libphonenumber-js": "^1.7.44",

--- a/src/components/ComingSoon/ComingSoon.scss
+++ b/src/components/ComingSoon/ComingSoon.scss
@@ -14,3 +14,8 @@
   justify-content: center;
   margin: 60px 0;
 }
+
+.wip {
+  width: 360px;
+  height: 264px;
+}

--- a/src/components/ComingSoon/ComingSoon.vue
+++ b/src/components/ComingSoon/ComingSoon.vue
@@ -5,7 +5,7 @@
       <TextParagraph class="description" size="medium"> {{ description }}</TextParagraph>
     </div>
     <div class="image-wrapper">
-      <WorkInProgress/>
+      <WorkInProgress class="wip"/>
     </div>
     <Button :data-testid="dataTestId" @click="onClose"> {{ closeButtonText }} </Button>
   </section>

--- a/src/components/LoadingSpinner/LoadingSpinner.scss
+++ b/src/components/LoadingSpinner/LoadingSpinner.scss
@@ -1,6 +1,8 @@
 @import '../../styles/colors';
 
 .spinner {
+  height: 40px;
+  width: 40px;
   margin: -2px 8px 0 0;
   animation: SpinnerSpin 1.5s infinite linear;
 

--- a/src/components/SelectBox/SelectBox.scss
+++ b/src/components/SelectBox/SelectBox.scss
@@ -55,13 +55,12 @@
   }
 }
 
-
-
 .icon {
+  height: 16px;
+  width: 16px;
   position: absolute;
   right: 12px;
   top: 20px;
-  transform: scale(1.3);
 
   ::v-deep path {
     fill: $blue-500;


### PR DESCRIPTION
## Description

* Updated `b2c-mapp-ui-assets` npm dependency to the latest version and fixed a few SVG icon overrides that were broken from the latest assets update.

## Testing

  * `npm run lint`: **PASS**
  * `npm run test`: **PASS**
  *  Testing locally with Storybook: **PASS**

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
