### PR TITLE
Updating b2c-mapp-ui, all copy text comes from props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -14,6 +14,10 @@ const props = {
     default: '',
     validator(value) { return (!value || availableTypes.includes(value)); },
   },
+  loadingText: {
+    type: String,
+    default: 'Cargando...',
+  },
   href: String,
   link: Boolean,
   loading: Boolean,

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -40,6 +40,9 @@ const defaultExample = () => ({
     contents: {
       default: text('Button Contents', 'Example Button'),
     },
+    loadingText: {
+      default: text('Loading Text', 'Cargando...'),
+    },
   },
   methods: {
     onClick: action('Clicked!'),
@@ -53,6 +56,7 @@ const defaultExample = () => ({
           <Button :type="type"
                   :href="href"
                   :loading="loading"
+                  :loading-text="loadingText"
                   :drop-shadow="dropShadow"
                   :disabled="disabled"
                   @click="onClick"

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -19,7 +19,7 @@
           :data-testid="`${baseDataTestIdToUse}-loading`"
       >
         <!-- TODO: Implement progress filling the background (See: https://www.figma.com/file/7qn2DSkgoUT5i9hIt4FL1C/Storybook?node-id=1%3A2) once we've discussed further with the design team -->
-        Cargando...
+        {{ loadingText }}
       </em>
       <span v-if="!loading"
             class="default-wrapper"


### PR DESCRIPTION
## Description
This PR will resolve #36 by updating b2c-mapp-ui to ensure that all copy text comes from props (no raw text except for default prop values)

## Testing
  * `npm run lint`: **PASS**
  * `npm run test`: **PASS**

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
