### PR TITLE
Add loadingText props to components that use Button with loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -62,7 +62,7 @@ const methods = {
     this.isPressed = !this.isPressed;
   },
   onClick(event) {
-    if (this.disabled) { return; }
+    if (this.disabled || this.loading) { return; }
     if (this.isPressed) { this.isPressed = false; }
     this.$emit('click', event);
   },

--- a/src/components/ConfirmationToastDialog/ConfirmationToastDialog.js
+++ b/src/components/ConfirmationToastDialog/ConfirmationToastDialog.js
@@ -23,6 +23,10 @@ const props = {
   secondaryButtonText: String,
   value: Boolean,
   loading: Boolean,
+  loadingText: {
+    type: String,
+    default: 'Cargando...',
+  },
   disabled: Boolean,
 };
 

--- a/src/components/ConfirmationToastDialog/ConfirmationToastDialog.stories.js
+++ b/src/components/ConfirmationToastDialog/ConfirmationToastDialog.stories.js
@@ -20,6 +20,9 @@ const defaultExample = () => ({
     description: {
       default: text('Description', 'Example Description'),
     },
+    loadingText: {
+      default: text('Loading Text', 'Cargando...'),
+    },
     confirmButtonText: {
       default: text('Confirm Button Text', 'Confirm'),
     },
@@ -63,6 +66,7 @@ const defaultExample = () => ({
                                  :confirm-button-text="confirmButtonText"
                                  :secondary-button-text="secondaryButtonText"
                                  :loading="loading"
+                                 :loading-text="loadingText"
                                  :disabled="disabled"
                                  @dismiss="onDismiss"
                                  @confirm="onConfirm"

--- a/src/components/ConfirmationToastDialog/ConfirmationToastDialog.vue
+++ b/src/components/ConfirmationToastDialog/ConfirmationToastDialog.vue
@@ -27,6 +27,7 @@
         <Button v-if="confirmButtonText"
                 class="confirm"
                 :loading="loading"
+                :loading-text="loadingText"
                 :disabled="disabled"
                 :data-test-id="`${dataTestId}-action-confirm`"
                 @click="onConfirm"

--- a/src/components/WrappedButton/WrappedButton.js
+++ b/src/components/WrappedButton/WrappedButton.js
@@ -20,6 +20,10 @@ const props = {
   },
   href: String,
   loading: Boolean,
+  loadingText: {
+    type: String,
+    default: 'Cargando...',
+  },
   disabled: Boolean,
   id: String,
   name: String,

--- a/src/components/WrappedButton/WrappedButton.stories.js
+++ b/src/components/WrappedButton/WrappedButton.stories.js
@@ -30,6 +30,9 @@ const defaultExample = () => ({
     loading: {
       default: boolean('Is Loading?', false),
     },
+    loadingText: {
+      default: text('Loading Text', 'Cargando...'),
+    },
     href: {
       default: text('href', ''),
     },
@@ -48,6 +51,7 @@ const defaultExample = () => ({
         <WrappedButton :type="type"
                        :href="href"
                        :loading="loading"
+                       :loading-text="loadingText"
                        :disabled="disabled"
                        @click="onClick"
         >

--- a/src/components/WrappedButton/WrappedButton.vue
+++ b/src/components/WrappedButton/WrappedButton.vue
@@ -5,6 +5,7 @@
             :href="href"
             :type="type"
             :loading="loading"
+            :loading-text="loadingText"
             :disabled="disabled"
             @click="onClick"
     >


### PR DESCRIPTION
## Description

  * Updated the `Button` component to stop emitting a `click` event when in `loading` state.
  * Updated `ConfirmationToastDialog` to support the new `loadingText` prop for the `Button` component that it uses.
  * Updated `WrappedButton` to support the new `loadingText` prop for the `Button` component that it uses.

## Testing

  * `npm run lint`: **PASS**
  * `npm run test`: **PASS**
  * Manual testing with local Storybook: **PASS**

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
