### PR TITLE
Stop adding spaces in BankAccountNumberInputField by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.0.6",
+  "version": "7.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.0.6",
+  "version": "7.1.0",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/BankAccountNumberInputField/BankAccountNumberInputField.js
+++ b/src/components/BankAccountNumberInputField/BankAccountNumberInputField.js
@@ -27,6 +27,7 @@ const props = {
   disabled: Boolean,
   readonly: Boolean,
   startFocused: Boolean,
+  autoformat: Boolean,
 };
 
 const data = function () {
@@ -107,7 +108,7 @@ const methods = {
     event.preventDefault();
   },
   updateInputValueWithFormatting() {
-    if (this.accountNumberWithoutSpaces.length > this.bankAccountTemplate.length) { return; }
+    if (!this.autoformat || (this.accountNumberWithoutSpaces.length > this.bankAccountTemplate.length)) { return; }
     this.inputValue = this.parsedAccountNumber;
   },
 };

--- a/src/components/BankAccountNumberInputField/BankAccountNumberInputField.stories.js
+++ b/src/components/BankAccountNumberInputField/BankAccountNumberInputField.stories.js
@@ -26,6 +26,9 @@ const defaultExample = () => ({
     readonly: {
       default: boolean('Is Readonly?', false),
     },
+    autoformat: {
+      default: boolean('Is Autoformatting Enabled?', false),
+    },
     label: {
       default: text('Label', 'Example BankAccount Field'),
     },
@@ -54,6 +57,7 @@ const defaultExample = () => ({
         <div>
           <BankAccountNumberInputField :disabled="disabled"
                                        :readonly="readonly"
+                                       :autoformat="autoformat"
                                        :label="label"
                                        :error-label="errorLabel"
                                        v-model="value"
@@ -91,6 +95,16 @@ const examples = () => ({
         <div style="width: 500px">
           <label>With a valid value:</label>
           <BankAccountNumberInputField country-code="MX"
+                                       label="Introduce un CLABE"
+                                       error-label="Invalid CLABE number"
+                                       value="138211000000000127"
+          />
+        </div>
+        <br>
+        <div style="width: 500px">
+          <label>With a autoformatting enabled:</label>
+          <BankAccountNumberInputField country-code="MX"
+                                       autoformat
                                        label="Introduce un CLABE"
                                        error-label="Invalid CLABE number"
                                        value="138211000000000127"

--- a/src/components/BankAccountNumberInputField/BankAccountNumberInputField.test.js
+++ b/src/components/BankAccountNumberInputField/BankAccountNumberInputField.test.js
@@ -51,8 +51,8 @@ describe('BankAccountNumberInputField unit test:', () => {
     expect(isBlurEmitted).toBeTruthy();
   });
 
-  it('Should apply right format for given value: ', () => new Promise((resolve) => {
-    const wrapper = mount(BankAccountNumberInputField, { propsData: { ...defaultProps, value: '138211000000000127' } });
+  it('Should apply the correct format when autoformat is enabled, for the given value: ', () => new Promise((resolve) => {
+    const wrapper = mount(BankAccountNumberInputField, { propsData: { ...defaultProps, autoformat: true, value: '138211000000000127' } });
     setTimeout(() => {
       const input = wrapper.find('input');
       expect(input.element.value).toEqual('138 211 00000000012 7');
@@ -60,8 +60,18 @@ describe('BankAccountNumberInputField unit test:', () => {
     });
   }));
 
+  it('Should apply the correct format when autoformat is disabled, for the given value: ', () => new Promise((resolve) => {
+    const inputValue = '138211000000000127';
+    const wrapper = mount(BankAccountNumberInputField, { propsData: { ...defaultProps, value: inputValue } });
+    setTimeout(() => {
+      const input = wrapper.find('input');
+      expect(input.element.value).toEqual(inputValue);
+      resolve();
+    });
+  }));
+
   it('Should take given input value: ', () => new Promise((resolve) => {
-    const newValue = '138 21';
+    const newValue = '13821';
     const wrapper = mount(BankAccountNumberInputField, { propsData: { ...defaultProps, value: '138211000000000127' } });
     const input = wrapper.find('input');
     input.setValue('13821');
@@ -75,7 +85,7 @@ describe('BankAccountNumberInputField unit test:', () => {
 
   it('Should not allow value with a length greater than its max-length: ', async () => {
     const newValue = '138 211 00000000012 79';
-    const initialValue = '138 211 00000000012 7';
+    const initialValue = '138211000000000127';
     const wrapper = mount(BankAccountNumberInputField, { propsData: { ...defaultProps, value: '138211000000000127' } });
     wrapper.vm.$options.watch.inputValue.call(wrapper.vm, newValue);
     await wrapper.vm.$nextTick();
@@ -83,7 +93,7 @@ describe('BankAccountNumberInputField unit test:', () => {
   });
 
   it('Should apply right format even if max-length of the field is not reached', () => new Promise((resolve) => {
-    const wrapper = mount(BankAccountNumberInputField, { propsData: { ...defaultProps, value: '138211000000000127' } });
+    const wrapper = mount(BankAccountNumberInputField, { propsData: { ...defaultProps, autoformat: true, value: '138211000000000127' } });
     const input = wrapper.find('input');
     input.setValue('13821');
     input.trigger('change');


### PR DESCRIPTION
## Description

  * Updated the `BankAccountNumberInputField` adding a new `autoformat` prop (`false` by default) to control whether we add spaces automatically. Also updated the Storybook stories for this component and its Unit Tests.
  * Bumped the MINOR version in `package.json`

## Testing

  * `npm run lint`: **PASS**
  * `npm run test`: **PASS**
  * Local testing with Storybook: **PASS**

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [x] **MINOR** adds functionality in a backwards-compatible manner.
- [ ] **PATCH** backwards-compatible bug fixes.
