### PR TITLE
219 - Update phone number field per Design Feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/PhoneNumberField/PhoneNumberField.js
+++ b/src/components/PhoneNumberField/PhoneNumberField.js
@@ -26,7 +26,7 @@ const props = {
     required: true,
     validator(value) { return availableCountryCodes.includes(value); },
   },
-  hideCountryCode: Boolean,
+  hideCountryCodeUntilFocus: Boolean,
   startFocused: Boolean,
   label: String,
   errorLabel: String,
@@ -41,6 +41,7 @@ const props = {
 
 const data = function () {
   return {
+    isFocused: false,
     inputValue: this.value,
   };
 };
@@ -57,6 +58,11 @@ const computed = {
     const result = `+${getCountryCallingCode(this.countryCode, phoneNumberMetadata)}`;
     return result;
   },
+  hideCountryCode() {
+    if (!this.hideCountryCodeUntilFocus) { return; }
+    const result = (!this.isFocused && !this.inputValue);
+    return result;
+  },
 };
 
 const methods = {
@@ -64,9 +70,11 @@ const methods = {
     this.$emit('input', this.inputValue);
   },
   onFocus(event) {
+    this.isFocused = true;
     this.$emit('focus', event);
   },
   onBlur(event) {
+    this.isFocused = false;
     this.$emit('blur', event);
   },
   supressNonDigitCharacterEntry(event) {

--- a/src/components/PhoneNumberField/PhoneNumberField.stories.js
+++ b/src/components/PhoneNumberField/PhoneNumberField.stories.js
@@ -32,8 +32,8 @@ const defaultExample = () => ({
     countryCode: {
       default: select('Country Code', [...availableCountryCodes], defaultCountryCode),
     },
-    hideCountryCode: {
-      default: boolean('Hide Country Code?', false),
+    hideCountryCodeUntilFocus: {
+      default: boolean('Hide Country Code until focus?', false),
     },
     disabled: {
       default: boolean('Is Disabled?', false),
@@ -88,7 +88,7 @@ const defaultExample = () => ({
         <PhoneNumberField v-model="value"
                           ref="field"
                           :country-code="countryCode"
-                          :hide-country-code="hideCountryCode"
+                          :hide-country-code-until-focus="hideCountryCodeUntilFocus"
                           :disabled="disabled"
                           :readonly="readonly"
                           :label="label"
@@ -157,10 +157,10 @@ const moreExamples = () => ({
           />
         </div>
         <div style="width: 500px">
-          <p>With Hidden Country Code</p>
+          <p>With Hidden Country Code (until focused)</p>
           <PhoneNumberField :country-code="defaultCountryCode"
-                            hide-country-code
-                            label="With hidden Country Code"
+                            hide-country-code-until-focus
+                            label="With hidden Country Code (until focused)"
           />
         </div>
         <div style="width: 500px">

--- a/src/components/PhoneNumberField/PhoneNumberField.test.js
+++ b/src/components/PhoneNumberField/PhoneNumberField.test.js
@@ -59,16 +59,22 @@ describe('UI/forms/PhoneNumberField', () => {
     expect(errorLabel).toBeTruthy();
   });
 
-  it('Should show country code if hideCountryCode is false', () => {
-    const { getByTestId } = render(PhoneNumberField, { propsData: { ...defaultProps, hideCountryCode: false, value: '551234123234324' } });
+  it('Should show country code if hideCountryCodeUntilFocus is false', () => {
+    const { getByTestId } = render(PhoneNumberField, { propsData: { ...defaultProps, hideCountryCodeUntilFocus: false, value: '551234123234324' } });
     const prefixIsShown = getByTestId('phone-field-prefix').textContent.includes('+52');
     expect(prefixIsShown).toBeTruthy();
   });
 
-  it('Should NOT show country code if given hideCountryCode is true', () => {
-    const { queryAllByTestId } = render(PhoneNumberField, { propsData: { ...defaultProps, hideCountryCode: true, value: '551234123234324' } });
+  it('Should NOT show country code if given hideCountryCodeUntilFocus is true and there is no value', () => {
+    const { queryAllByTestId } = render(PhoneNumberField, { propsData: { ...defaultProps, hideCountryCodeUntilFocus: true } });
     const prefixIsNotShown = !queryAllByTestId('phone-field-prefix').length;
     expect(prefixIsNotShown).toBeTruthy();
+  });
+
+  it('Should show country code if given hideCountryCodeUntilFocus is true and there is a value', () => {
+    const { getByTestId } = render(PhoneNumberField, { propsData: { ...defaultProps, hideCountryCodeUntilFocus: true, value: '551234123234324' } });
+    const prefixIsShown = getByTestId('phone-field-prefix').textContent.includes('+52');
+    expect(prefixIsShown).toBeTruthy();
   });
 
   it('Should NOT show country code if is not given', () => {


### PR DESCRIPTION
## Description

  * Updated the `hideCountryCode` prop in the `PhonNumberField` component to: `hideCountryCodeUntilFocus` and modified the logic to only hide the country code when there is no value and unfocused. 
  * Updated the `PhoneNumberField` unit tests.
  * Bumped the MINOR version in `package.json`

## Testing

  * `npm run lint`: **PASS**
  * `npm run test`: **PASS**
  * Local testing with Storybook: **PASS**

## Screencap
  
  ![Screencap](https://user-images.githubusercontent.com/6749993/84898971-57aa6300-b0a8-11ea-9e21-bbbaa7436aac.gif)

## Checks
- [x] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [x] **MINOR** adds functionality in a backwards-compatible manner.
- [ ] **PATCH** backwards-compatible bug fixes.
