### PR TITLE
Add keypress and keyup events to select box and date picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/DateField/DateField.js
+++ b/src/components/DateField/DateField.js
@@ -37,6 +37,7 @@ const props = {
   readonly: Boolean,
   startFocused: Boolean,
   disabled: Boolean,
+  customValidation: Boolean,
 };
 
 const data = function () {
@@ -65,8 +66,7 @@ const computed = {
     return result;
   },
   errorLabelToShow() {
-    if (this.isValid) { return; }
-    return this.errorLabel;
+    if (this.customValidation || !this.isValid) { return this.errorLabel; }
   },
   formFieldFormattedDateText() {
     if (!this.datePickerValue) { return ''; }
@@ -100,15 +100,6 @@ const methods = {
     this.$emit('change', this.formFieldFormattedDateText);
     this.$emit('validate', validationPayload);
   },
-  focus() {
-    this.$refs.field.focus();
-  },
-  onFocus(event) {
-    this.$emit('focus', event);
-  },
-  onBlur(event) {
-    this.$emit('blur', event);
-  },
   updateInputValueWithFormatting() {
     if (!(this.autoformat && this.inputValue)) { return; }
     this.inputValue = this.autoformattedDate;
@@ -119,6 +110,29 @@ const methods = {
   updateCalendarValueIfNeeded() {
     if (!(this.inputValue && this.isValid)) { return; }
     this.datePickerValue = this.datePickerValueToUse;
+  },
+  onFocus(event) {
+    this.$emit('focus', event);
+  },
+  onBlur(event) {
+    this.$emit('blur', event);
+  },
+  onKeypress(event) {
+    this.$emit('keypress', event);
+  },
+  onKeyup(event) {
+    this.$emit('keyup', event);
+  },
+  onPaste(event) {
+    this.$emit('paste', event);
+  },
+  focus() {
+    if (!this.$refs.field) { return; }
+    this.$refs.field.focus();
+  },
+  blur() {
+    if (!this.$refs.field) { return; }
+    this.$refs.field.blur();
   },
 };
 

--- a/src/components/DateField/DateField.stories.js
+++ b/src/components/DateField/DateField.stories.js
@@ -41,6 +41,9 @@ const defaultExample = () => ({
     maxLength: {
       default: number('Max Length', 10),
     },
+    customValidation: {
+      default: boolean('Custom Validation?', false),
+    },
   },
   data() {
     return {
@@ -50,6 +53,9 @@ const defaultExample = () => ({
   methods: {
     onBlur: action('Blur!'),
     onFocus: action('Focus!'),
+    onPaste: action('Paste!'),
+    onKeyup: action('KeyUp!'),
+    onKeypress: action('KeyPress!'),
     onChange: action('Change!'),
     onValidate: action('Validate!'),
   },
@@ -65,9 +71,13 @@ const defaultExample = () => ({
                    :label="label"
                    :error-label="errorLabel"
                    :max-length="maxLength"
+                   :custom-validation="customValidation"
                    v-model="value"
                    @blur="onBlur"
                    @focus="onFocus"
+                   @keypress="onKeypress"
+                   @keyup="onKeyup"
+                   @paste="onPaste"
                    @change="onChange"
                    @validate="onValidate"
         />

--- a/src/components/DateField/DateField.vue
+++ b/src/components/DateField/DateField.vue
@@ -12,8 +12,11 @@
                :disabled="disabled"
                :max-length="maxLength"
                :start-focused="startFocused"
-               @blur="onBlur"
                @focus="onFocus"
+               @blur="onBlur"
+               @paste="onPaste"
+               @keypress="onKeypress"
+               @keyup="onKeyup"
     />
     <label v-if="datePicker"
            class="calendar-icon"

--- a/src/components/SelectBox/SelectBox.js
+++ b/src/components/SelectBox/SelectBox.js
@@ -18,6 +18,7 @@ const props = {
   id: String,
   name: String,
   disabled: Boolean,
+  errorLabel: String,
 };
 
 const data = function () {
@@ -27,12 +28,44 @@ const data = function () {
   };
 };
 
+const computed = {
+  labelToShow() {
+    const result = (this.errorLabel || this.label);
+    return result;
+  },
+};
+
 const methods = {
   emitInputEvent() {
     this.$emit('input', this.selectedValue);
   },
   toggleFocus() {
     this.isFocused = !this.isFocused;
+  },
+  onFocus(event) {
+    this.toggleFocus();
+    this.$emit('focus', event);
+  },
+  onBlur(event) {
+    this.toggleFocus();
+    this.$emit('blur', event);
+  },
+  onKeypress(event) {
+    this.$emit('keypress', event);
+  },
+  onKeyup(event) {
+    this.$emit('keyup', event);
+  },
+  onPaste(event) {
+    this.$emit('paste', event);
+  },
+  focus() {
+    if (!this.$refs.input) { return; }
+    this.$refs.input.focus();
+  },
+  blur() {
+    if (!this.$refs.input) { return; }
+    this.$refs.input.blur();
   },
 };
 
@@ -48,6 +81,7 @@ const watch = {
 const SelectBox = {
   components,
   props,
+  computed,
   data,
   methods,
   watch,

--- a/src/components/SelectBox/SelectBox.scss
+++ b/src/components/SelectBox/SelectBox.scss
@@ -91,3 +91,11 @@
   height: 2px;
   background-color: $blue-500;
 }
+
+.error:before {
+  background: $red-500;
+}
+
+.error .label {
+  color: $red-500;
+}

--- a/src/components/SelectBox/SelectBox.stories.js
+++ b/src/components/SelectBox/SelectBox.stories.js
@@ -23,6 +23,9 @@ const defaultExample = () => ({
     label: {
       default: text('Label', 'Example label'),
     },
+    errorLabel: {
+      default: text('Error Label', ''),
+    },
     disabled: {
       default: boolean('Is Disabled?', false),
     },
@@ -64,6 +67,11 @@ const defaultExample = () => ({
   },
   methods: {
     onInput: action('Changed!'),
+    onBlur: action('Blur!'),
+    onFocus: action('Focus!'),
+    onPaste: action('Paste!'),
+    onKeyup: action('KeyUp!'),
+    onKeypress: action('KeyPress!'),
   },
   template: `
     <div style="margin: 10px 50px 10px 50px;">
@@ -73,9 +81,15 @@ const defaultExample = () => ({
       <StorybookMobileDeviceSimulator :device="device">
         <SelectBox v-model="selectedValue"
                    :label="label"
+                   :error-label="errorLabel"
                    :options="options"
                    :disabled="disabled"
                    @input="onInput"
+                   @blur="onBlur"
+                   @focus="onFocus"
+                   @keypress="onKeypress"
+                   @keyup="onKeyup"
+                   @paste="onPaste"
         />
         <div style="margin: 20px;">
           Bound value: {{ selectedValue }}
@@ -85,9 +99,15 @@ const defaultExample = () => ({
         <p style="margin-left: 10px;">With a pre-selected value (specified by the consumer)</p>
         <SelectBox v-model="preSelectedValue"
                    :label="label"
+                   :error-label="errorLabel"
                    :options="preSelectedOptions"
                    :disabled="disabled"
                    @input="onInput"
+                   @blur="onBlur"
+                   @focus="onFocus"
+                   @keypress="onKeypress"
+                   @keyup="onKeyup"
+                   @paste="onPaste"
         />
         <div style="margin: 20px;">
           Bound value: {{ preSelectedValue }}

--- a/src/components/SelectBox/SelectBox.vue
+++ b/src/components/SelectBox/SelectBox.vue
@@ -1,18 +1,22 @@
 <template>
   <label class="select-box-container"
-         :class="{ focus: isFocused, disabled, 'no-value': !value }"
+         :class="{ focus: isFocused, disabled, 'no-value': !value, error: errorLabel }"
          :data-testid="`${dataTestId}-label`"
   >
-    <strong class="label">{{ label }}</strong>
+    <strong class="label">{{ labelToShow }}</strong>
     <ExpandSmallIcon/>
     <select :id="id"
+            ref="input"
             v-model="selectedValue"
             class="select"
             :name="name"
             :data-testid="`${dataTestId}-select`"
             :disabled="disabled"
-            @focus="toggleFocus"
-            @blur="toggleFocus"
+            @focus="onFocus"
+            @blur="onBlur"
+            @paste="onPaste"
+            @keypress="onKeypress"
+            @keyup="onKeyup"
     >
       <option v-for="({ value: optionValue, disabled: isOptionDisabled, selected, label: optionLabel }, index) in options"
               :key="`${optionValue}-${index}`"


### PR DESCRIPTION
## Description
  
  * Updated `SelectBox` and `DateField` to support `keyup`, `keypress`, `paste`, `blur`, and `focus` events 
  * Updated `SelectBox` to support the `errorLabel` prop.
  * Added a new `customValidation` prop to `DateField` to allow showing a custom errorLabel.
  * Updated Storybook stories for `SelectBox` and `DateField` to showcase their new features.
  * Bumped the MINOR version in `package.json`

## Testing

  * `npm run lint`: **PASS**
  * `npm run test`: **PASS**
  * Local testing with Storybook: **PASS**

## Checks
- [x] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [x] **MINOR** adds functionality in a backwards-compatible manner.
- [ ] **PATCH** backwards-compatible bug fixes.
