### PR TITLE
Disable confirm dialog button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.9.0",
+  "version": "7.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.9.0",
+  "version": "7.9.1",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/ConfirmationModalDialog/ConfirmationModalDialog.js
+++ b/src/components/ConfirmationModalDialog/ConfirmationModalDialog.js
@@ -19,7 +19,14 @@ const props = {
   dismissButtonText: String,
   value: Boolean,
   loading: Boolean,
-  disabled: Boolean,
+  confirmButtonDisabled: {
+    type: Boolean,
+    default: false,
+  },
+  dismissButtonDisabled: {
+    type: Boolean,
+    default: false,
+  },
 };
 
 const data = function () {

--- a/src/components/ConfirmationModalDialog/ConfirmationModalDialog.scss
+++ b/src/components/ConfirmationModalDialog/ConfirmationModalDialog.scss
@@ -68,4 +68,7 @@
   &.dismiss {
     color: $black-500;
   }
+  &.disabled {
+    color: $black-400;
+  }
 }

--- a/src/components/ConfirmationModalDialog/ConfirmationModalDialog.stories.js
+++ b/src/components/ConfirmationModalDialog/ConfirmationModalDialog.stories.js
@@ -126,9 +126,114 @@ const withCustomContent = () => ({
   `,
 });
 
+const withDismissButtonDisabled = () => ({
+  components: {
+    ConfirmationModalDialog,
+  },
+  data() {
+    return {
+      isShowing: false,
+    };
+  },
+  computed: {
+    showHideTitle() {
+      if (this.isShowing) { return 'Hide'; }
+      return 'Show';
+    },
+  },
+  methods: {
+    onDismiss: action('Dismissed!'),
+    onConfirm: action('Confirmed!'),
+    onClose: action('Closed!'),
+    toggleIsShowing() {
+      this.isShowing = !this.isShowing;
+    },
+  },
+  template: `
+    <div style="margin: 10px 50px 10px 50px;">
+      <h2><strong>ConfirmationModalDialog:</strong>&nbsp;Custom Content with disabled Dismiss Button.</h2>
+      <hr>
+      <div style="margin-top: 20px; width: 100px">
+        <ConfirmationModalDialog v-model="isShowing"
+                                 title="Custom Content with disabled Dismiss Button Example"
+                                 confirm-button-text="Got it"
+                                 dismiss-button-text="Never mind"
+                                 @dismiss="onDismiss"
+                                 @confirm="onConfirm"
+                                 @close="onClose"
+                                 dismissButtonDisabled
+        >
+          <div style="color: deeppink; margin: 20px">
+            This is some <strong>custom</strong> content
+          </div>
+        </ConfirmationModalDialog>
+      </div>
+      <div style="margin-top: 20px;">
+        Bound value: {{ isShowing }}
+      </div>
+      <div style="margin-top: 20px; display: flex; flex-direction: row; width: 100%; justify-content: center">
+        <button style="font-size: 20px; color: blue;" @click="toggleIsShowing">{{ showHideTitle }} Dialog</button>
+      </div>
+    </div>
+  `,
+});
+
+const withConfirmButtonDisabled = () => ({
+  components: {
+    ConfirmationModalDialog,
+  },
+  data() {
+    return {
+      isShowing: false,
+    };
+  },
+  computed: {
+    showHideTitle() {
+      if (this.isShowing) { return 'Hide'; }
+      return 'Show';
+    },
+  },
+  methods: {
+    onDismiss: action('Dismissed!'),
+    onConfirm: action('Confirmed!'),
+    onClose: action('Closed!'),
+    toggleIsShowing() {
+      this.isShowing = !this.isShowing;
+    },
+  },
+  template: `
+    <div style="margin: 10px 50px 10px 50px;">
+      <h2><strong>ConfirmationModalDialog:</strong>&nbsp;Custom Content with disabled Confirm Button.</h2>
+      <hr>
+      <div style="margin-top: 20px; width: 100px">
+        <ConfirmationModalDialog v-model="isShowing"
+                                 title="Custom Content with disabled Confirm Button Example"
+                                 confirm-button-text="Got it"
+                                 dismiss-button-text="Never mind"
+                                 @dismiss="onDismiss"
+                                 @confirm="onConfirm"
+                                 confirmButtonDisabled
+                                 @close="onClose"
+        >
+          <div style="color: deeppink; margin: 20px">
+            This is some <strong>custom</strong> content
+          </div>
+        </ConfirmationModalDialog>
+      </div>
+      <div style="margin-top: 20px;">
+        Bound value: {{ isShowing }}
+      </div>
+      <div style="margin-top: 20px; display: flex; flex-direction: row; width: 100%; justify-content: center">
+        <button style="font-size: 20px; color: blue;" @click="toggleIsShowing">{{ showHideTitle }} Dialog</button>
+      </div>
+    </div>
+  `,
+});
 export {
   defaultExample,
   withCustomContent,
+  withDismissButtonDisabled,
+  withConfirmButtonDisabled,
 };
 
 export default ConfirmationModalDialogStories;

--- a/src/components/ConfirmationModalDialog/ConfirmationModalDialog.test.js
+++ b/src/components/ConfirmationModalDialog/ConfirmationModalDialog.test.js
@@ -15,7 +15,6 @@ describe('ConfirmationmodalDialog unit test', () => {
     description: 'description',
     confirmButtonText: 'confirm',
     dismissButtonText: 'dismiss',
-    disabled: false,
   };
 
   it('Should be intially visible if given value is set to true', () => {
@@ -75,6 +74,24 @@ describe('ConfirmationmodalDialog unit test', () => {
       expect(confirmIsShown).toBeTruthy();
     });
 
+    it('Should be disabled if given confirmButtonDisabled is set to true', () => {
+      const { getByTestId } = render(ConfirmationModalDialog, { propsData: { ...defaultProps, confirmButtonDisabled: true } });
+      const confirmIsDisabled = getByTestId('dialog-action-confirm-button').getAttribute('disabled') === 'disabled';
+      expect(confirmIsDisabled).toBeTruthy();
+    });
+
+    it('Should be NOT disabled if given confirmButtonDisabled is set to false', () => {
+      const { getByTestId } = render(ConfirmationModalDialog, { propsData: { ...defaultProps, confirmButtonDisabled: false } });
+      const confirmIsNotDisabled = !getByTestId('dialog-action-confirm-button').getAttribute('disabled');
+      expect(confirmIsNotDisabled).toBeTruthy();
+    });
+
+    it('Should be NOT disabled if given confirmButtonDisabled by default', () => {
+      const { getByTestId } = render(ConfirmationModalDialog, { propsData: { ...defaultProps } });
+      const confirmIsNotDisabled = !getByTestId('dialog-action-confirm-button').getAttribute('disabled');
+      expect(confirmIsNotDisabled).toBeTruthy();
+    });
+
     it('Should NOT show action-confirm button when confirm is NOT given', () => {
       const { queryAllByTestId } = render(ConfirmationModalDialog, { propsData: {
         ...defaultProps,
@@ -98,6 +115,24 @@ describe('ConfirmationmodalDialog unit test', () => {
       const { getByTestId } = render(ConfirmationModalDialog, { propsData: { ...defaultProps } });
       const dismissIsShown = getByTestId('dialog-action-dismiss-button').textContent.includes('dismiss');
       expect(dismissIsShown).toBeTruthy();
+    });
+
+    it('Should be disabled if given dismissButtonDisabled is set to true', () => {
+      const { getByTestId } = render(ConfirmationModalDialog, { propsData: { ...defaultProps, dismissButtonDisabled: true } });
+      const dismissIsDisabled = getByTestId('dialog-action-dismiss-button').getAttribute('disabled') === 'disabled';
+      expect(dismissIsDisabled).toBeTruthy();
+    });
+
+    it('Should be NOT disabled if given dismissButtonDisabled is set to false', () => {
+      const { getByTestId } = render(ConfirmationModalDialog, { propsData: { ...defaultProps, dismissButtonDisabled: false } });
+      const dismissIsNotDisabled = !getByTestId('dialog-action-dismiss-button').getAttribute('disabled');
+      expect(dismissIsNotDisabled).toBeTruthy();
+    });
+
+    it('Should be NOT disabled if given dismissButtonDisabled by default', () => {
+      const { getByTestId } = render(ConfirmationModalDialog, { propsData: { ...defaultProps } });
+      const dismissIsNotDisabled = !getByTestId('dialog-action-dismiss-button').getAttribute('disabled');
+      expect(dismissIsNotDisabled).toBeTruthy();
     });
 
     it('Should NOT show action-dismiss button when dismiss is NOT given', () => {

--- a/src/components/ConfirmationModalDialog/ConfirmationModalDialog.vue
+++ b/src/components/ConfirmationModalDialog/ConfirmationModalDialog.vue
@@ -25,7 +25,7 @@
       <div class="actions" :data-testid="`${dataTestId}-actions`">
         <button v-if="dismissButtonText"
                 class="action dismiss"
-                :disabled="disabled"
+                :disabled="dismissButtonDisabled"
                 :data-testid="`${dataTestId}-action-dismiss-button`"
                 @click="onDismiss"
         >
@@ -33,7 +33,7 @@
         </button>
         <button v-if="confirmButtonText"
                 class="action"
-                :disabled="disabled"
+                :disabled="confirmButtonDisabled"
                 :data-testid="`${dataTestId}-action-confirm-button`"
                 @click="onConfirm"
         >

--- a/src/components/ConfirmationModalDialog/ConfirmationModalDialog.vue
+++ b/src/components/ConfirmationModalDialog/ConfirmationModalDialog.vue
@@ -25,6 +25,7 @@
       <div class="actions" :data-testid="`${dataTestId}-actions`">
         <button v-if="dismissButtonText"
                 class="action dismiss"
+                :class="{ disabled: dismissButtonDisabled }"
                 :disabled="dismissButtonDisabled"
                 :data-testid="`${dataTestId}-action-dismiss-button`"
                 @click="onDismiss"
@@ -33,6 +34,7 @@
         </button>
         <button v-if="confirmButtonText"
                 class="action"
+                :class="{ disabled: confirmButtonDisabled }"
                 :disabled="confirmButtonDisabled"
                 :data-testid="`${dataTestId}-action-confirm-button`"
                 @click="onConfirm"


### PR DESCRIPTION
## Description
The current `disabled` property affects to both buttons in the `ConfirmationModalDialog`. Once this ConfirmationModalDialog is visible, it can not be possible to close it because both buttons are disabled.

The goal of this task is to provide a way to disable each button separately. `confirmButtonDisabled` & `dismissButtonDisabled`

## Testing
 - Tested in Storybook
 - Unit tested

## Screenshots/Captures

`black-400` color applied to disabled button: 

![image](https://user-images.githubusercontent.com/61735887/88787158-ba0c7e00-d193-11ea-8d84-ea7d11b4cb65.png)

![image](https://user-images.githubusercontent.com/61735887/88787177-c264b900-d193-11ea-99d9-671a56c96ec8.png)


## Checks
- [x] Requires lib version update

## Versioning impact
- [x] **PATCH** backwards-compatible bug fixes.


![](https://media.giphy.com/media/OOwT2tGmcqpmo/giphy.gif)
