### PR TITLE
Improve how SelectBox handles default option with empty value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.10.2",
+  "version": "7.10.3",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/SelectBox/SelectBox.js
+++ b/src/components/SelectBox/SelectBox.js
@@ -33,6 +33,12 @@ const computed = {
     const result = (this.errorLabel || this.label);
     return result;
   },
+  hasEmptyOption() {
+    if (!(this.options && this.options.length)) { return; }
+    const hasEmptyValue = ({ value }) => !value;
+    const result = this.options.some(hasEmptyValue);
+    return result;
+  },
 };
 
 const methods = {

--- a/src/components/SelectBox/SelectBox.stories.js
+++ b/src/components/SelectBox/SelectBox.stories.js
@@ -117,8 +117,76 @@ const defaultExample = () => ({
   `,
 });
 
+const withNoValueInitiallySelected = () => ({
+  components: {
+    SelectBox,
+    StorybookMobileDeviceSimulator,
+  },
+  props: {
+    device: {
+      default: select('Simulated Mobile Device', [...availableDevices], availableDevices[0]),
+    },
+  },
+  data() {
+    return {
+      selectedValue: '',
+      options: [
+        {
+          label: 'Choose an option',
+          value: '',
+          disabled: true,
+        },
+        {
+          label: 'Option 1',
+          value: 'option1',
+        },
+        {
+          label: 'Option 2',
+          value: 'option2',
+        },
+        {
+          label: 'Option 3',
+          value: 'option3',
+        },
+      ],
+    };
+  },
+  methods: {
+    onInput: action('Changed!'),
+    onBlur: action('Blur!'),
+    onFocus: action('Focus!'),
+    onPaste: action('Paste!'),
+    onKeyup: action('KeyUp!'),
+    onKeypress: action('KeyPress!'),
+  },
+  template: `
+    <div style="margin: 10px 50px 10px 50px;">
+      <h2><strong>SelectBox:</strong>&nbsp;With no value initially selected.</h2>
+      <hr>
+      <StorybookMobileDeviceSimulator :device="device">
+        <SelectBox v-model="selectedValue"
+                   label="With no value selected"
+                   :error-label="errorLabel"
+                   :options="options"
+                   :disabled="disabled"
+                   @input="onInput"
+                   @blur="onBlur"
+                   @focus="onFocus"
+                   @keypress="onKeypress"
+                   @keyup="onKeyup"
+                   @paste="onPaste"
+        />
+        <div style="margin: 20px;">
+          Bound value: {{ selectedValue }}
+        </div>
+      </StorybookMobileDeviceSimulator>
+    </div>
+  `,
+});
+
 export {
   defaultExample,
+  withNoValueInitiallySelected,
 };
 
 export default SelectBoxStories;

--- a/src/components/SelectBox/SelectBox.vue
+++ b/src/components/SelectBox/SelectBox.vue
@@ -1,6 +1,6 @@
 <template>
   <label class="select-box-container"
-         :class="{ focus: isFocused, disabled, 'no-value': !value, error: errorLabel }"
+         :class="{ focus: isFocused, disabled, 'no-value': (!hasEmptyOption && !value), error: errorLabel }"
          :data-testid="`${dataTestId}-label`"
   >
     <strong class="label">{{ labelToShow }}</strong>


### PR DESCRIPTION
## Description

  * Fixed how SelectBox displays an empty selection when there is a default option with no value.
  * Added a new Storybook story for this issue
  * Bumped the `PATCH` version in `package.json`

## Testing

  * `npm run lint`: **PASS**
  * `npm run test`: **PASS**
  * Local testing with Storybook: **PASS**

## Screenshots/Captures

  * **Before** (Broken):
    ![Before (Broken)](https://user-images.githubusercontent.com/6749993/89160721-cd439300-d571-11ea-8121-062b20fde9f6.png)

  * **After** (Fixed): 
    ![After (Fixed)](https://user-images.githubusercontent.com/6749993/89160744-d7659180-d571-11ea-8858-d1e476f114d8.png)


## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
