### PR TITLE
Adding maxPhoneNumberLength to PhoneNumberField component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.10.3",
+  "version": "7.10.4",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/PhoneNumberField/PhoneNumberField.js
+++ b/src/components/PhoneNumberField/PhoneNumberField.js
@@ -37,7 +37,10 @@ const props = {
   maxLength: Number,
   lengthHint: Number,
   lengthHintLabel: String,
-  maxPhoneNumberLength: Number,
+  maxPhoneNumberLength: {
+    type: Number,
+    default: 10,
+  },
 };
 
 const data = function () {

--- a/src/components/PhoneNumberField/PhoneNumberField.js
+++ b/src/components/PhoneNumberField/PhoneNumberField.js
@@ -3,7 +3,7 @@ import { AsYouType, getCountryCallingCode, getCountries } from 'libphonenumber-j
 import FormField from '../FormField/FormField.vue';
 import TextParagraph from '../TextParagraph/TextParagraph.vue';
 import phoneNumberMetadata from '../../../data/libphonenumber-metadata.min.json';
-import { onlyDigitsRegexp } from '../../lib/regexHelper';
+import { onlyDigitsRegexp, allSpacesRegexp } from '../../lib/regexHelper';
 
 const availableCountryCodes = getCountries(phoneNumberMetadata);
 
@@ -37,6 +37,7 @@ const props = {
   maxLength: Number,
   lengthHint: Number,
   lengthHintLabel: String,
+  maxPhoneNumberLength: Number,
 };
 
 const data = function () {
@@ -85,6 +86,8 @@ const methods = {
     this.$refs.field.focus();
   },
   isPhoneNumberValid() {
+    const inputValueWithoutSpaces = this.inputValue.replace(allSpacesRegexp, '');
+    if (this.maxPhoneNumberLength && (inputValueWithoutSpaces.length > this.maxPhoneNumberLength)) { return false; }
     const asYouType = new AsYouType(this.countryCode, phoneNumberMetadata);
     asYouType.input((this.inputValue || ''));
     const result = asYouType.isPossible();

--- a/src/components/PhoneNumberField/PhoneNumberField.stories.js
+++ b/src/components/PhoneNumberField/PhoneNumberField.stories.js
@@ -44,6 +44,9 @@ const defaultExample = () => ({
     maxLength: {
       default: number('Max Lenth'),
     },
+    maxPhoneNumberLength: {
+      default: number('Max Phone Number Length', 10),
+    },
     lengthHint: {
       default: number('Length Hint'),
     },
@@ -94,6 +97,7 @@ const defaultExample = () => ({
                           :label="label"
                           :error-label="errorLabel"
                           :max-length="maxLength"
+                          :max-phone-number-length="maxPhoneNumberLength"
                           :length-hint="lengthHint"
                           :length-hint-label="lengthHintLabel"
                           @blur="onBlur"


### PR DESCRIPTION
## Description
This PR will update the PhoneNumberField component in order to add a maxPhoneNumberLength
(The default max-length will be 10 digits)
Also, this PR forms part in solving issue https://github.com/lana/b2c-access/issues/281

## Testing
This was tested locally using storybook

## Screenshots/Captures
![phone-number-fix-mapp-ui](https://user-images.githubusercontent.com/53623817/89261554-dd9c5200-d5f3-11ea-922f-ce6c8aa87d1d.gif)

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
