### PR TITLE
Added noBorder prop to ContentItem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.10.10",
+  "version": "7.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.10.10",
+  "version": "7.11.1",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/ContentItem/ContentItem.js
+++ b/src/components/ContentItem/ContentItem.js
@@ -28,6 +28,7 @@ const props = {
     default: true,
   },
   disabled: Boolean,
+  noBorder: Boolean,
 };
 
 const methods = {

--- a/src/components/ContentItem/ContentItem.scss
+++ b/src/components/ContentItem/ContentItem.scss
@@ -27,6 +27,10 @@ $item-box-size: 48px;
   border: solid 1px $black-300;
 }
 
+.no-border {
+  border: none;
+}
+
 .body {
   height: 100%;
   display: flex;

--- a/src/components/ContentItem/ContentItem.stories.js
+++ b/src/components/ContentItem/ContentItem.stories.js
@@ -28,6 +28,9 @@ const defaultExample = () => ({
     hasForwardButton: {
       default: boolean('Has Forward Button?', true),
     },
+    noBorder: {
+      default: boolean('Hide Border?', false),
+    },
     title: {
       default: text('Title', 'Example Title'),
     },
@@ -46,6 +49,7 @@ const defaultExample = () => ({
         <ContentItem :title="title"
                      :meta-text="metaText"
                      :has-forward-button="hasForwardButton"
+                     :no-border="noBorder"
                      :disabled="disabled"
                      @click="onClick"
         >
@@ -97,8 +101,9 @@ const withIcon = () => ({
       <h2><strong>ContentItem:</strong>&nbsp;Example With Icon</h2>
       <hr>
       <StorybookMobileDeviceSimulator :device="device">
-        <ContentItem title="Example with Image"
+        <ContentItem title="Example with Icon"
                      meta-text="Example metatext"
+                     no-border
         >
           <DocumentFilledIcon/>
         </ContentItem>

--- a/src/components/ContentItem/ContentItem.vue
+++ b/src/components/ContentItem/ContentItem.vue
@@ -5,8 +5,9 @@
       @click="emitClickEvent"
   >
     <div v-if="$slots.default"
-         :data-testid="`${dataTestId}-media-icon`"
          class="media"
+         :class="{ 'no-border': noBorder }"
+         :data-testid="`${dataTestId}-media-icon`"
     >
       <slot/>
     </div>


### PR DESCRIPTION
## Description

  * Bumped the `MINOR` version in `package.json`.
  * Added `noBorder` prop to `ContentItem`

## Testing

  * `npm run lint`: **PASS**
  * `npm run test`: **PASS**
  * `npm run prepare`: **PASS**
  * Local testing with Storybook: **PASS**

## Screenshots/Captures
  ![Screenshot 2020-08-25 at 13 39 43](https://user-images.githubusercontent.com/6749993/91170214-d2ab7d80-e6d8-11ea-8e82-e9eb37a88101.png)


## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [x] **MINOR** adds functionality in a backwards-compatible manner.
- [ ] **PATCH** backwards-compatible bug fixes.
