### PR TITLE
Update SelectBox and DateField icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.12.1",
+  "version": "7.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.12.1",
+  "version": "7.12.2",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/DateField/DateField.scss
+++ b/src/components/DateField/DateField.scss
@@ -9,6 +9,13 @@
   height: 100%;
   padding-right: 16px;
 
+  .icon {
+    height: 20px;
+    min-height: 20px;
+    width: 20px;
+    min-width: 20px;
+  }
+
   &::before {
     content: '';
     display: inline-block;

--- a/src/components/SelectBox/SelectBox.scss
+++ b/src/components/SelectBox/SelectBox.scss
@@ -49,15 +49,13 @@
   .label {
     color: $black-500;
   }
-
-  .icon ::v-deep path {
-    fill: $black-500;
-  }
 }
 
-.icon {
-  height: 16px;
-  width: 16px;
+.select-icon {
+  height: 20px;
+  min-height: 20px;
+  width: 20px;
+  min-width: 20px;
   position: absolute;
   right: 12px;
   top: 20px;

--- a/src/components/SelectBox/SelectBox.vue
+++ b/src/components/SelectBox/SelectBox.vue
@@ -4,7 +4,7 @@
          :data-testid="`${dataTestId}-label`"
   >
     <strong class="label">{{ labelToShow }}</strong>
-    <ExpandSmallIcon/>
+    <ExpandSmallIcon v-if="!disabled" class="select-icon"/>
     <select :id="id"
             ref="input"
             v-model="selectedValue"


### PR DESCRIPTION
## Description

  * Updated the icon size for `SelectBox` and `DateField` components to match Figma designs.
  * Update `SelectBox` to stop showing the dropdown icon when `disabled`
  * Bumped the `PATCH` version in `package.json`

## Testing

  * `npm run lint`: **PASS** 
  * `npm run test`: **PASS** 
  * `npm run prepare`: **PASS** 
  * Local testing with Storybook: **PASS** 

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
