### PR TITLE
CurrencyField updates and improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.13.1",
+  "version": "7.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -999,9 +999,9 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.0.tgz",
-      "integrity": "sha512-LFEsP+t3wkYBlis8w6/kmnd6Kb1dxTd+wGJ8MlxTGzQo//ehtqlVL4S9DNUa53+dtPSQobN2CXx4d81FqC58cw==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.5.tgz",
+      "integrity": "sha512-9aIoee+EhjySZ6vY5hnLjigHzunBlscx9ANKutkeWTJTx6m5Rbq6Ic01tLvO54lSusR+BxV7u4UDdCmXv5aagg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",
@@ -1428,6 +1428,26 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
       "dev": true
+    },
+    "@eslint/eslintrc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.0.tgz",
+      "integrity": "sha512-bfL5365QSCmH6cPeFT7Ywclj8C7LiF7sO6mUGzZhtAMV7iID1Euq6740u/SRi4C80NOnVz/CEfK8/HO+nCAPJg==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "import-fresh": "^3.2.1",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
+        }
+      }
     },
     "@hapi/address": {
       "version": "2.1.4",
@@ -11792,12 +11812,13 @@
       }
     },
     "eslint": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.7.0.tgz",
-      "integrity": "sha512-1KUxLzos0ZVsyL81PnRN335nDtQ8/vZUD6uMtWbF+5zDtjKcsklIi78XoE0MVL93QvWTu+E5y44VyyCsOMBrIg==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.8.0.tgz",
+      "integrity": "sha512-qgtVyLZqKd2ZXWnLQA4NtVbOyH56zivOAdBFWE54RFkSZjokzNrcP4Z0eVWsZ+84ByXv+jL9k/wE1ENYe8xRFw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.1.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -11807,7 +11828,7 @@
         "eslint-scope": "^5.1.0",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^1.3.0",
-        "espree": "^7.2.0",
+        "espree": "^7.3.0",
         "esquery": "^1.2.0",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
@@ -23473,9 +23494,9 @@
       }
     },
     "rollup": {
-      "version": "2.26.8",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.8.tgz",
-      "integrity": "sha512-li9WaJYc5z9WzV1jhZbPQCrsOpGNsI+Li1qyrn5n745ZNSnlkRlBtj1Hs+Z0Dc2N1+P7HT34UKAEASqN9Th8cg==",
+      "version": "2.26.9",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.9.tgz",
+      "integrity": "sha512-XIiWYLayLqV+oY4S2Lub/shJq4uk/QQLwWToYCL4LjZbYHbFK3czea4UDVRUJu+zNmKmxq5Zb/OG7c5HSvH2TQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.13.1",
+  "version": "7.13.2",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-export-default-from": "^7.8.3",
     "@babel/plugin-proposal-export-namespace-from": "^7.8.3",
-    "@babel/plugin-transform-runtime": "^7.11.0",
+    "@babel/plugin-transform-runtime": "^7.11.5",
     "@rollup/plugin-babel": "^5.0.0",
     "@rollup/plugin-commonjs": "^15.0.0",
     "@rollup/plugin-json": "^4.0.3",
@@ -71,11 +71,11 @@
     "@vue/test-utils": "^1.0.5",
     "autoprefixer": "^9.8.6",
     "babel-eslint": "^10.1.0",
-    "eslint": "^7.6.0",
+    "eslint": "^7.8.0",
     "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-vue": "^6.2.2",
-    "rollup": "^2.26.8",
+    "rollup": "^2.26.9",
     "rollup-plugin-node-globals": "^1.4.0",
     "rollup-plugin-postcss": "^3.1.8",
     "rollup-plugin-terser": "^7.0.1",

--- a/src/components/CurrencyField/CurrencyField.js
+++ b/src/components/CurrencyField/CurrencyField.js
@@ -1,4 +1,4 @@
-import { CurrencyDirective, getValue } from 'vue-currency-input';
+import { CurrencyDirective, getValue, setValue } from 'vue-currency-input';
 
 import TextParagraph from '../TextParagraph/TextParagraph.vue';
 
@@ -20,7 +20,7 @@ const props = {
     default: 100,
   },
   value: {
-    type: String,
+    type: [String, Number],
     default: '',
   },
   id: String,
@@ -122,6 +122,10 @@ const methods = {
 
 const watch = {
   inputValue() {
+    if (!this.getUnformattedValue()) { // NOTE: This logic is required in order to force-set the initial value (whenever it starts off as undefined and is later programatically changed) for the vue-currency-input directive that we are using.
+      setValue(this.$refs.input, this.inputValue);
+      return;
+    }
     this.emitInputEvent();
   },
   value() {

--- a/src/components/CurrencyField/CurrencyField.stories.js
+++ b/src/components/CurrencyField/CurrencyField.stories.js
@@ -4,6 +4,7 @@ import { withKnobs, select, boolean, text, number } from '@storybook/addon-knobs
 import StorybookMobileDeviceSimulator from '../StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator.vue';
 import { availableDevices } from '../StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator';
 import CurrencyField from './CurrencyField.vue';
+import { sleep } from '@/lib/sleepHelper';
 
 const CurrencyFieldStories = {
   component: CurrencyField,
@@ -105,8 +106,68 @@ const defaultExample = () => ({
   `,
 });
 
+const withPrefilledValue = () => ({
+  components: {
+    CurrencyField,
+    StorybookMobileDeviceSimulator,
+  },
+  props: {
+    device: {
+      default: select('Simulated Mobile Device', [...availableDevices], availableDevices[0]),
+    },
+  },
+  data() {
+    return {
+      value: null,
+      unformattedValue: '',
+    };
+  },
+  methods: {
+    onBlur: action('Blur!'),
+    onFocus: action('Focus!'),
+    onPaste: action('Paste!'),
+    onKeyup: action('KeyUp!'),
+    onKeypress: action('KeyPress!'),
+  },
+  watch: {
+    value() {
+      this.unformattedValue = this.$refs.field.getUnformattedValue();
+    },
+  },
+  async mounted() {
+    await sleep(100);
+    this.value = 12345;
+  },
+  template: `
+    <div style="margin: 10px 50px 10px 50px;">
+      <h2><strong>CurrencyField:</strong>&nbsp;Example with a pre-filled value. (it should appear with proper formatting)</h2>
+      <hr>
+      <StorybookMobileDeviceSimulator :device="device">
+        <CurrencyField v-model="value"
+                       ref="field"
+                       label="Example with Prefilled Value"
+                       @blur="onBlur"
+                       @focus="onFocus"
+                       @keypress="onKeypress"
+                       @keyup="onKeyup"
+                       @paste="onPaste"
+        />
+        <br>
+        <div style="margin: 20px;">
+          Bound value: {{ value }}
+        </div>
+        <br>
+        <div style="margin: 20px;">
+          Unformatted value: {{ unformattedValue }}
+        </div>
+      </StorybookMobileDeviceSimulator>
+    </div>
+  `,
+});
+
 export {
   defaultExample,
+  withPrefilledValue,
 };
 
 export default CurrencyFieldStories;

--- a/src/lib/sleepHelper.js
+++ b/src/lib/sleepHelper.js
@@ -1,0 +1,5 @@
+const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+export {
+  sleep,
+};


### PR DESCRIPTION
## Description

  * Updated the `CurrencyField` component's `value` prop to accept either a `Number` or a `String`.
  * Fixed logic for initial `null`/`undefined` values for `CurrencyField` and added a story for that scenario.
  * Updated NPM dependencies
  * Bumped the `PATCH` version in `package.json`

## Testing

  * `npm run lint`: **PASS**
  * `npm run test`: **PASS**
  * `npm run prepare`: **PASS**
  * Local testing with Storybook: **PASS**

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
