### PR TITLE
Added lengthHint prop to BankAccountNumberField

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.13.2",
+  "version": "7.14.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1430,17 +1430,49 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.0.tgz",
-      "integrity": "sha512-bfL5365QSCmH6cPeFT7Ywclj8C7LiF7sO6mUGzZhtAMV7iID1Euq6740u/SRi4C80NOnVz/CEfK8/HO+nCAPJg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
+      "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
+        "acorn": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+          "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+          "dev": true
+        },
+        "espree": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+          "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.4.0",
+            "acorn-jsx": "^5.2.0",
+            "eslint-visitor-keys": "^1.3.0"
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
         "strip-json-comments": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4639,16 +4671,70 @@
       }
     },
     "@testing-library/dom": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.23.0.tgz",
-      "integrity": "sha512-H5m090auYH+obdZmsaYLrSWC5OauWD2CvNbz88KBxQJoXgkJzbU0DpAG8BS7Evj5WqCC3nAAKrLS6vw0ljUYLg==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.1.tgz",
+      "integrity": "sha512-TemHWY59gvzcScGiE5eooZpzYk9GaED0TuuK4WefbIc/DQg0L5wOpnj7MIEeAGF3B7Ekf1kvmVnQ97vwz4Lmhg==",
       "dev": true,
       "requires": {
+        "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.10.3",
         "@types/aria-query": "^4.2.0",
         "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.1",
         "pretty-format": "^26.4.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@testing-library/vue": {
@@ -11812,13 +11898,13 @@
       }
     },
     "eslint": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.8.0.tgz",
-      "integrity": "sha512-qgtVyLZqKd2ZXWnLQA4NtVbOyH56zivOAdBFWE54RFkSZjokzNrcP4Z0eVWsZ+84ByXv+jL9k/wE1ENYe8xRFw==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.8.1.tgz",
+      "integrity": "sha512-/2rX2pfhyUG0y+A123d0ccXtMm7DV7sH1m3lk9nk2DZ2LReq39FXHueR9xZwshE5MdfSf0xunSaMWRqyIA6M1w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@eslint/eslintrc": "^0.1.0",
+        "@eslint/eslintrc": "^0.1.3",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -26476,9 +26562,9 @@
       }
     },
     "vue-currency-input": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/vue-currency-input/-/vue-currency-input-1.22.1.tgz",
-      "integrity": "sha512-5cdMt5lHFx+YFeljAAp8r2gI5S6oykywER5xiFsryk4XSSklezdv+v4VnKCgWaYyZmQ69x0Qs5qqrxindoFjTg=="
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/vue-currency-input/-/vue-currency-input-1.22.2.tgz",
+      "integrity": "sha512-PK3FUMvHSQZh6peWXBQe30xOSltWryLQUJ47nOeqLFVV8XNBV8btdSbZ9IxSQaTs/LP32THYqMD6OhB2tHtaOw=="
     },
     "vue-docgen-api": {
       "version": "4.31.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "7.13.2",
+  "version": "7.14.1",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"
@@ -43,7 +43,7 @@
     "fast-async": "^6.3.8",
     "libphonenumber-js": "^1.7.57",
     "vue": "^2.6.12",
-    "vue-currency-input": "^1.22.1"
+    "vue-currency-input": "^1.22.2"
   },
   "devDependencies": {
     "@babel/plugin-proposal-export-default-from": "^7.8.3",
@@ -61,7 +61,7 @@
     "@storybook/addon-notes": "^5.3.21",
     "@storybook/storybook-deployer": "^2.8.5",
     "@storybook/vue": "^6.0.21",
-    "@testing-library/dom": "^7.23.0",
+    "@testing-library/dom": "^7.24.1",
     "@testing-library/vue": "^5.0.2",
     "@vue/cli-plugin-babel": "~4.5.2",
     "@vue/cli-plugin-eslint": "~4.5.2",
@@ -71,7 +71,7 @@
     "@vue/test-utils": "^1.0.5",
     "autoprefixer": "^9.8.6",
     "babel-eslint": "^10.1.0",
-    "eslint": "^7.8.0",
+    "eslint": "^7.8.1",
     "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-vue": "^6.2.2",

--- a/src/components/BankAccountNumberInputField/BankAccountNumberInputField.js
+++ b/src/components/BankAccountNumberInputField/BankAccountNumberInputField.js
@@ -29,6 +29,7 @@ const props = {
   startFocused: Boolean,
   autoformat: Boolean,
   showLengthHint: Boolean,
+  lengthHint: Number,
   lengthHintLabel: String,
 };
 
@@ -83,9 +84,9 @@ const computed = {
     const result = this.bankAccountTemplate.length;
     return result;
   },
-  lengthHint() {
+  lengthHintToUse() {
     if (!this.showLengthHint) { return; }
-    const result = this.maxLength;
+    const result = (this.lengthHint || this.maxLength);
     return result;
   },
 };

--- a/src/components/BankAccountNumberInputField/BankAccountNumberInputField.stories.js
+++ b/src/components/BankAccountNumberInputField/BankAccountNumberInputField.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { withKnobs, select, boolean, text } from '@storybook/addon-knobs';
+import { withKnobs, select, boolean, text, number } from '@storybook/addon-knobs';
 
 import StorybookMobileDeviceSimulator from '../StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator.vue';
 import { availableDevices } from '../StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator';
@@ -31,6 +31,9 @@ const defaultExample = () => ({
     },
     showLengthHint: {
       default: boolean('Show length hint?', false),
+    },
+    lengthHint: {
+      default: number('Length Hint Number'),
     },
     lengthHintLabel: {
       default: text('Length Hint Label', ''),
@@ -68,6 +71,7 @@ const defaultExample = () => ({
                                        :error-label="errorLabel"
                                        :show-length-hint="showLengthHint"
                                        :length-hint-label="lengthHintLabel"
+                                       :length-hint="lengthHint"
                                        v-model="value"
                                        @blur="onBlur"
                                        @focus="onFocus"

--- a/src/components/BankAccountNumberInputField/BankAccountNumberInputField.test.js
+++ b/src/components/BankAccountNumberInputField/BankAccountNumberInputField.test.js
@@ -92,6 +92,24 @@ describe('BankAccountNumberInputField unit test:', () => {
     expect(wrapper.vm.$data.inputValue).toEqual(initialValue);
   });
 
+  it('Should allow showing the length hint value independently of the max-length: ', async () => {
+    const newValue = '138211000000000127';
+    const wrapper = mount(BankAccountNumberInputField, {
+      propsData: {
+        ...defaultProps,
+        value: newValue,
+        lengthHint: 10,
+        lengthHintLabel: 'foo',
+        showLengthHint: true,
+      },
+    });
+    const lengthHint = wrapper.find('.hint');
+    await wrapper.vm.$nextTick();
+    const hasLengthHint = lengthHint.element.textContent.includes('10 foo');
+    expect(hasLengthHint).toBeTruthy();
+    expect(wrapper.vm.$data.inputValue).toEqual(newValue);
+  });
+
   it('Should apply right format even if max-length of the field is not reached', () => new Promise((resolve) => {
     const wrapper = mount(BankAccountNumberInputField, { propsData: { ...defaultProps, autoformat: true, value: '138211000000000127' } });
     const input = wrapper.find('input');

--- a/src/components/BankAccountNumberInputField/BankAccountNumberInputField.vue
+++ b/src/components/BankAccountNumberInputField/BankAccountNumberInputField.vue
@@ -10,7 +10,7 @@
              type="tel"
              :name="name"
              :max-length="maxLength"
-             :length-hint="lengthHint"
+             :length-hint="lengthHintToUse"
              :length-hint-label="lengthHintLabel"
              @blur="onBlur"
              @focus="onFocus"


### PR DESCRIPTION
## Description

  * Updated `BankAccountNumberField` adding a new `lengthHint` prop for overriding the length hint that is shown (which previously was set to always use the maxlength value).
  * Updated NPM dependencies.
  * Bumped the `MINOR` version in `package.json`.

## Testing

  * `npm run lint`: **PASS**
  * `npm run test`: **PASS**
  * `npm run prepare`: **PASS**
  * Local testing with Storybook: **PASS**

## Checks
- [x] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [x] **MINOR** adds functionality in a backwards-compatible manner.
- [ ] **PATCH** backwards-compatible bug fixes.
