### PR TITLE
Add CallToActionScreen to library.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/library.js
+++ b/src/library.js
@@ -1,6 +1,7 @@
 import ActionItem from './components/ActionItem/ActionItem.vue';
 import BankAccountNumberInputField from './components/BankAccountNumberInputField/BankAccountNumberInputField.vue';
 import Button from './components/Button/Button.vue';
+import CallToActionScreen from './components/CallToActionScreen/CallToActionScreen.vue';
 import ConfirmationModalDialog from './components/ConfirmationModalDialog/ConfirmationModalDialog.vue';
 import ConfirmationToastDialog from './components/ConfirmationToastDialog/ConfirmationToastDialog.vue';
 import ContentItem from './components/ContentItem/ContentItem.vue';
@@ -38,6 +39,7 @@ export {
   ActionItem,
   BankAccountNumberInputField,
   Button,
+  CallToActionScreen,
   ConfirmationModalDialog,
   ConfirmationToastDialog,
   ContentItem,


### PR DESCRIPTION
## Description
Add CallToActionScreen to library.js, bumped version to 8.1.0

## Testing
- npm run lint: **PASS**
- npm run test: **PASS**

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [x] **MINOR** adds functionality in a backwards-compatible manner.
- [ ] **PATCH** backwards-compatible bug fixes.
