### PR TITLE
More style fixes for FormField's Clear Button and PhoneNumberField's flag icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.2.6",
+  "version": "8.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.2.6",
+  "version": "8.2.7",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/CurrencyField/CurrencyField.scss
+++ b/src/components/CurrencyField/CurrencyField.scss
@@ -130,6 +130,7 @@
   font-size: 16px;
   width: 44px;
   height: 38px;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .clear-icon {

--- a/src/components/FormField/FormField.scss
+++ b/src/components/FormField/FormField.scss
@@ -131,6 +131,7 @@
   font-size: 16px;
   width: 44px;
   height: 38px;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .clear-icon {

--- a/src/components/PhoneNumberField/PhoneNumberField.scss
+++ b/src/components/PhoneNumberField/PhoneNumberField.scss
@@ -23,6 +23,7 @@
 
 .flag {
   font-size: 16px;
+  line-height: 30px;
   margin-right: 10px;
   margin-top: -2px;
 }


### PR DESCRIPTION
## Description

  * Removed the blue tap highlight color from the clear icon for `FormField` and `CurrencyField`
  * Fixed the CSS `line-height` attribute for the flag icon in `PhoneNumberField` (this was causing issues for some devices)
  * Bumped the `PATCH` version in `package.json`

## Testing

  * `npm run lint`: **PASS**
  * `npm run test`: **PASS**
  * `npm run prepare`: **PASS**
  * Local testing with Storybook (and Chrome's mobile device simulator): **PASS**

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
