### PR TITLE
Add test-id for SelectBox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"
@@ -41,7 +41,7 @@
     "@lana/b2c-mapp-ui-assets": "^4.8.6",
     "core-js": "^3.6.4",
     "fast-async": "^6.3.8",
-    "libphonenumber-js": "^1.8.1",
+    "libphonenumber-js": "^1.8.2",
     "vue": "^2.6.12",
     "vue-currency-input": "^1.22.3"
   },

--- a/src/components/PhoneNumberField/PhoneNumberField.vue
+++ b/src/components/PhoneNumberField/PhoneNumberField.vue
@@ -23,7 +23,7 @@
              @keypress="supressNonDigitCharacterEntry"
   >
     <div v-if="!hideCountryCode" class="prefix-container">
-      <p class="flag">{{ flagEmoji }}</p>
+      <div class="flag">{{ flagEmoji }}</div>
       <TextParagraph :data-test-id="`${dataTestId}-prefix`">{{ prefix }}</TextParagraph>
     </div>
   </FormField>

--- a/src/components/SelectBox/SelectBox.vue
+++ b/src/components/SelectBox/SelectBox.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="outer-select-box-container">
-    <div class="select-box-container" :class="{ focus: isFocused, disabled, readonly, 'no-value': (!hasEmptyOption && !value), error: errorLabel }">
+    <div class="select-box-container"
+         :class="{ focus: isFocused, disabled, readonly, 'no-value': (!hasEmptyOption && !value), error: errorLabel }"
+         :data-testid="`${dataTestId}-container`"
+    >
       <label class="select-box" :data-testid="`${dataTestId}-label`">
         <strong class="label">{{ label }}</strong>
         <ExpandSmallIcon v-if="!readonly" class="select-icon"/>


### PR DESCRIPTION
## Description

  * Added a `data-testid` attribute to the `SelectBox`'s container element.
  * Changed the `PhoneNumberField`'s flag emoji container from `<p>` to: `<div>` (in hopes of potentially improving how it renders for some Android devices).
  * Updated npm dependencies
  * Bumped the `PATCH` version in `package.json`

## Testing

 * `npm run lint`: **PASS**
 * `npm run test`: **PASS**
 * `npm run prepare`: **PASS**
 * Local testing with Storybook: **PASS**

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
