### PR TITLE
Remove Flag emoji from PhoneNumberField

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/PhoneNumberField/PhoneNumberField.js
+++ b/src/components/PhoneNumberField/PhoneNumberField.js
@@ -59,13 +59,6 @@ const computed = {
     const result = asYouType.input(this.inputValue);
     return result;
   },
-  flagEmoji() {
-    if (!this.countryCode) { return ''; }
-    const flagCharacterFinalCode = 0x1F1A5;
-    const mapFlagCharacter = (character) => (character.charCodeAt() + flagCharacterFinalCode);
-    const result = String.fromCodePoint(...[...this.countryCode.toUpperCase()].map(mapFlagCharacter));
-    return result;
-  },
   prefix() {
     if (!this.countryCode) { return; }
     const result = `+${getCountryCallingCode(this.countryCode, phoneNumberMetadata)}`;

--- a/src/components/PhoneNumberField/PhoneNumberField.scss
+++ b/src/components/PhoneNumberField/PhoneNumberField.scss
@@ -13,17 +13,10 @@
 
 .filled {
   ::v-deep input {
-    text-indent: 60px;
+    text-indent: 35px;
   }
 
   .prefix-container {
     opacity: 1;
   }
-}
-
-.flag {
-  font-size: 16px;
-  line-height: 30px;
-  margin-right: 10px;
-  margin-top: -2px;
 }

--- a/src/components/PhoneNumberField/PhoneNumberField.vue
+++ b/src/components/PhoneNumberField/PhoneNumberField.vue
@@ -23,7 +23,6 @@
              @keypress="supressNonDigitCharacterEntry"
   >
     <div v-if="!hideCountryCode" class="prefix-container">
-      <div class="flag">{{ flagEmoji }}</div>
       <TextParagraph :data-test-id="`${dataTestId}-prefix`">{{ prefix }}</TextParagraph>
     </div>
   </FormField>


### PR DESCRIPTION
## Description

  * Removed the Flag emoji from `PhoneNumberField` (per the Design team's request)
  * Bumped the `MINOR` version in `package.json`

## Testing

  * `npm run lint`: **PASS**
  * `npm run test`: **PASS**
  * `npm run prepare`: **PASS**
  * Local testing with Storybook: **PASS**

## Checks
- [ ] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
