### PR TITLE
ContentItem html on title and MetaText

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.10.3",
+  "version": "8.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.10.3",
+  "version": "8.11.0",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/ContentItem/ContentItem.js
+++ b/src/components/ContentItem/ContentItem.js
@@ -47,6 +47,10 @@ const computed = {
     const result = (this.success || this.hasForwardButton);
     return result;
   },
+  hasMetaText() {
+    const result = (this.metaText || this.$slots['custom-meta-text']);
+    return result;
+  },
   iconName() {
     const result = (this.hasForwardButton && !this.success) ? 'ChevronRightIcon' : 'Success';
     return result;

--- a/src/components/ContentItem/ContentItem.stories.js
+++ b/src/components/ContentItem/ContentItem.stories.js
@@ -5,6 +5,7 @@ import { DocumentFilledIcon, CheckCircleIcon, ClockIcon } from '@lana/b2c-mapp-u
 import StorybookMobileDeviceSimulator from '../StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator.vue';
 import { availableDevices } from '../StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator';
 import ContentItem from './ContentItem.vue';
+import TextField from '../TextField/TextField.vue';
 
 const ContentItemStories = {
   component: ContentItem,
@@ -239,15 +240,6 @@ const noImageAndCustomForwardIcon = () => ({
     device: {
       default: select('Simulated Mobile Device', [...availableDevices], availableDevices[0]),
     },
-    disabled: {
-      default: boolean('Is Disabled?', false),
-    },
-    hasForwardButton: {
-      default: boolean('Has Forward Button?', true),
-    },
-    success: {
-      default: boolean('Has Success forward icon?', true),
-    },
     title: {
       default: text('Title', 'Example Title'),
     },
@@ -280,6 +272,57 @@ const noImageAndCustomForwardIcon = () => ({
   `,
 });
 
+const customTitleAndCustomMetaText = () => ({
+  components: {
+    ContentItem,
+    DocumentFilledIcon,
+    StorybookMobileDeviceSimulator,
+    TextField,
+  },
+  data() {
+    return {
+      title: 'Example <b>Title</b>',
+      metaText: 'Example <br /> Metatext',
+    };
+  },
+  props: {
+    device: {
+      default: select('Simulated Mobile Device', [...availableDevices], availableDevices[0]),
+    },
+  },
+  methods: {
+    onClick: action('Click!'),
+  },
+  template: `
+    <div style="margin: 10px 50px 10px 50px;">
+      <h2><strong>ContentItem:</strong>&nbsp;A list item with success state, it does not redirect anywhere, it just provides success/completed information.</h2>
+      <hr>
+      <StorybookMobileDeviceSimulator :device="device">
+        <div style="padding: 16px;">
+          <ContentItem no-border
+                      @click="onClick"
+          >
+            <template v-slot:custom-title>
+              <span v-if="title" v-html="title" />
+            </template>
+            <template v-slot:custom-meta-text>
+              <span v-if="metaText" v-html="metaText" />
+            </template>
+          </ContentItem>
+          <hr />
+          <h2> Content values </h2>
+          <TextField v-model="title"
+                    label="Title"
+          />
+          <TextField v-model="metaText"
+                    label="MetaText"
+          />
+        </div>
+      </StorybookMobileDeviceSimulator>
+    </div>
+  `,
+});
+
 export {
   defaultExample,
   withImage,
@@ -287,6 +330,7 @@ export {
   successState,
   withCustomForwardIcon,
   noImageAndCustomForwardIcon,
+  customTitleAndCustomMetaText,
 };
 
 export default ContentItemStories;

--- a/src/components/ContentItem/ContentItem.test.js
+++ b/src/components/ContentItem/ContentItem.test.js
@@ -101,4 +101,28 @@ describe('ContentItem unit test', () => {
     const customForwardIconVisible = getByTestId('custom-forward-icon');
     expect(customForwardIconVisible).toBeTruthy();
   });
+
+  it('Should show custom title', () => {
+    const { getByTestId } = render(
+      ContentItem,
+      {
+        slots: { 'custom-title': '<b data-testid="custom-title">Bold text</b>' },
+        propsData: { ...defaultProps },
+      },
+    );
+    const customTitleVisible = getByTestId('custom-title');
+    expect(customTitleVisible).toBeTruthy();
+  });
+
+  it('Should show custom metaText', () => {
+    const { getByTestId } = render(
+      ContentItem,
+      {
+        slots: { 'custom-meta-text': '<span data-testid="custom-meta-text">Text <br />newline</span>' },
+        propsData: { ...defaultProps },
+      },
+    );
+    const customMetaTextVisible = getByTestId('custom-meta-text');
+    expect(customMetaTextVisible).toBeTruthy();
+  });
 });

--- a/src/components/ContentItem/ContentItem.vue
+++ b/src/components/ContentItem/ContentItem.vue
@@ -15,12 +15,14 @@
       <slot/>
     </div>
     <div :data-testid="`${dataTestId}-heading`" class="body">
-      <Heading class="title" size="medium">{{ title }}</Heading>
-      <TextParagraph v-if="metaText"
+      <Heading class="title" size="medium">
+        <slot name="custom-title">{{ title }}</slot>
+      </Heading>
+      <TextParagraph v-if="hasMetaText"
                      class="meta-text"
                      :data-test-id="`${dataTestId}-meta-text`"
       >
-        {{ metaText }}
+        <slot name="custom-meta-text">{{ metaText }}</slot>
       </TextParagraph>
     </div>
     <slot name="forward-icon">


### PR DESCRIPTION
## Description
Allow title and metatext to have html as content

## Checks
- [x] Requires documentation update
- [x] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [x] **MINOR** adds functionality in a backwards-compatible manner.
- [ ] **PATCH** backwards-compatible bug fixes.
