### PR TITLE
Propagate click event on copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.12.2",
+  "version": "8.12.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.12.2",
+  "version": "8.12.3",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/CopyableListItem/CopyableListItem.js
+++ b/src/components/CopyableListItem/CopyableListItem.js
@@ -24,9 +24,16 @@ const props = {
   disabled: Boolean,
 };
 
+const methods = {
+  onClick(event) {
+    this.$emit('click', event);
+  },
+};
+
 const CopyableListItem = {
   components,
   props,
+  methods,
 };
 
 export default CopyableListItem;

--- a/src/components/CopyableListItem/CopyableListItem.stories.js
+++ b/src/components/CopyableListItem/CopyableListItem.stories.js
@@ -1,101 +1,189 @@
-import { withKnobs, select, boolean, text } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, select } from '@storybook/addon-knobs';
 import { InfoIcon, DocumentFilledIcon } from '@lana/b2c-mapp-ui-assets/dist/index';
 
 import StorybookMobileDeviceSimulator from '../StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator.vue';
 import { availableDevices } from '../StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator';
 import CopyableListItem from './CopyableListItem.vue';
+import RenderString from '../../lib/renderString';
 
-const CopyableListItemStories = {
-  component: CopyableListItem,
-  title: 'Components/CopyableListItem',
-  decorators: [withKnobs],
-};
-
-const defaultExample = () => ({
-  components: {
-    CopyableListItem,
-    InfoIcon,
-    StorybookMobileDeviceSimulator,
-  },
+const deviceDecorator = () => ({
   props: {
     device: {
       default: select('Simulated Mobile Device', [...availableDevices], availableDevices[0]),
     },
-    disabled: {
-      default: boolean('Is Disabled?', false),
-    },
-    hideButton: {
-      default: boolean('Is copy button hidden?', false),
-    },
-    title: {
-      default: text('Title', 'Example Title'),
-    },
-    text: {
-      default: text('Text', 'Example Text'),
-    },
   },
+  components: { StorybookMobileDeviceSimulator },
   template: `
     <div style="margin: 10px 50px 10px 50px;">
-      <h2><strong>CopyableListItem:</strong>&nbsp;A list item with a convenient copy button.</h2>
+      <h2><strong>ContentRadioList:</strong>&nbsp;A control that allows a user to select an option by showing all available options as a list of radio buttons.</h2>
       <hr>
       <StorybookMobileDeviceSimulator :device="device">
-        <CopyableListItem :title="title"
-                          :text="text"
-                          :hide-button="hideButton"
-                          :disabled="disabled"
-
-        >
-          <InfoIcon/>
-        </CopyableListItem>
+        <story />
       </StorybookMobileDeviceSimulator>
     </div>
   `,
 });
+deviceDecorator.argTypes = {
+  device: { control: { type: 'select', options: [...availableDevices] } },
+};
 
-const moreExampleStates = () => ({
+const CopyableListItemStories = {
+  component: CopyableListItem,
+  title: 'Components/CopyableListItem',
+  decorators: [withKnobs, deviceDecorator],
+  args: {
+    title: 'Example Title',
+    text: 'Example Text',
+    dataTestId: '',
+    hideButton: false,
+    disabled: false,
+    default: '<InfoIcon width="24" />',
+  },
+  argTypes: {
+    hideButton: { name: 'Is copy button hidden?', control: 'boolean' },
+    disabled: { name: 'Is disabled?', control: 'boolean' },
+    title: { name: 'Title', control: { type: 'text' } },
+    text: { name: 'Text', control: { type: 'text' } },
+    dataTestId: { control: { type: 'text' } },
+    default: {
+      control: {
+        type: 'text',
+      },
+      table: {
+        type: {
+          summary: null,
+        },
+      },
+    },
+  },
+};
+
+const defaultExample = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: {
+    CopyableListItem,
+    RenderString,
+  },
+  methods: {
+    onClick: action('Clicked!'),
+  },
+  computed: {
+    defaultSlot() {
+      return this.default;
+    },
+  },
+  template: `
+    <CopyableListItem :title="title"
+                      :text="text"
+                      :hide-button="hideButton"
+                      :disabled="disabled"
+                      @click="onClick"
+    >
+      <RenderString :string="defaultSlot" />
+    </CopyableListItem>
+  `,
+});
+defaultExample.parameters = {
+  docs: {
+    source: {
+      code: `
+<CopyableListItem :title="title"
+                  :text="text"
+                  :hide-button="hideButton"
+                  :disabled="disabled"
+                  @click="onClick"
+>
+  <InfoIcon/>
+</CopyableListItem>
+      `,
+    },
+  },
+};
+
+const moreExampleStates = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
   components: {
     CopyableListItem,
     InfoIcon,
     DocumentFilledIcon,
-    StorybookMobileDeviceSimulator,
   },
-  props: {
-    device: {
-      default: select('Simulated Mobile Device', [...availableDevices], availableDevices[0]),
-    },
+  methods: {
+    onClick: action('Clicked!'),
   },
   template: `
-    <div style="margin: 10px 50px 10px 50px;">
-      <h2><strong>CopyableListItem:</strong>&nbsp;More example states.</h2>
-      <hr>
-      <StorybookMobileDeviceSimulator :device="device">
         <ul>
           <CopyableListItem title="An info example"
                             text="Text to be copied"
+                            @click="onClick"
           >
-            <DocumentFilledIcon/>
+            <DocumentFilledIcon width="24"/>
           </CopyableListItem>
           <CopyableListItem title="Random URL (with hidden copy button)"
                             text="https://source.unsplash.com/random/24x24"
                             hide-button
+                            @click="onClick"
           >
             <img src="https://source.unsplash.com/random/24x24"/>
           </CopyableListItem>
           <CopyableListItem title="Some Title"
                             text="1234567890ABCDE"
+                            @click="onClick"
           >
-            <DocumentFilledIcon/>
+            <DocumentFilledIcon width="24"/>
           </CopyableListItem>
           <CopyableListItem title="Another Title"
                             text="1234567890ABCDE"
+                            @click="onClick"
           >
-            <InfoIcon/>
+            <InfoIcon width="24"/>
           </CopyableListItem>
         </ul>
-      </StorybookMobileDeviceSimulator>
-    </div>
   `,
 });
+moreExampleStates.argTypes = {
+  ...CopyableListItemStories.argTypes,
+  default: { table: { disable: true } },
+  title: { table: { disable: true } },
+  text: { table: { disable: true } },
+  disabled: { table: { disable: true } },
+  hideButton: { table: { disable: true } },
+  dataTestId: { table: { disable: true } },
+};
+moreExampleStates.parameters = {
+  docs: {
+    source: {
+      code: `
+<ul>
+  <CopyableListItem title="An info example"
+                    text="Text to be copied"
+                    @click="onClick"
+  >
+    <DocumentFilledIcon/>
+  </CopyableListItem>
+  <CopyableListItem title="Random URL (with hidden copy button)"
+                    text="https://source.unsplash.com/random/24x24"
+                    hide-button
+                    @click="onClick"
+  >
+    <img src="https://source.unsplash.com/random/24x24"/>
+  </CopyableListItem>
+  <CopyableListItem title="Some Title"
+                    text="1234567890ABCDE"
+                    @click="onClick"
+  >
+    <DocumentFilledIcon/>
+  </CopyableListItem>
+  <CopyableListItem title="Another Title"
+                    text="1234567890ABCDE"
+                    @click="onClick"
+  >
+    <InfoIcon/>
+  </CopyableListItem>
+</ul>`,
+    },
+  },
+};
 
 export {
   defaultExample,

--- a/src/components/CopyableListItem/CopyableListItem.test.js
+++ b/src/components/CopyableListItem/CopyableListItem.test.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/vue';
+import { render, fireEvent } from '@testing-library/vue';
 
 import CopyableListItem from './CopyableListItem.vue';
 import { silenceDeprecationErrorsAndInnerComponentWarnings } from '../../lib/testUtils';
@@ -43,5 +43,13 @@ describe('CopyableListItem unit test', () => {
     const { queryAllByTestId } = render(CopyableListItem, { stubs: { default: defaultSlot }, propsData: { ...defaultProps } });
     const buttonExists = queryAllByTestId('copyable-list-item-copy-to-clipboard-button-button').length;
     expect(buttonExists).toBeTruthy();
+  });
+
+  it('should emit an event when is clicked', () => {
+    const { getByTestId, emitted } = render(CopyableListItem, { stubs: { default: defaultSlot }, propsData: { ...defaultProps } });
+    const element = getByTestId('copyable-list-item-copy-to-clipboard-button-button');
+    fireEvent.click(element);
+    const isEmitted = emitted();
+    expect(isEmitted).toBeTruthy();
   });
 });

--- a/src/components/CopyableListItem/CopyableListItem.vue
+++ b/src/components/CopyableListItem/CopyableListItem.vue
@@ -24,6 +24,7 @@
       <CopyToClipboardButton :value-to-copy="text"
                              :disabled="disabled"
                              :data-test-id="`${dataTestId}-copy-to-clipboard-button`"
+                             @click="onClick"
       />
     </TextParagraph>
   </li>


### PR DESCRIPTION
## Description
Propagate CopyToClipboardButton click event 

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
