### PR TITLE
AmountInput replace function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.15.1",
+  "version": "8.15.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3272,9 +3272,9 @@
       }
     },
     "@lana/b2c-mapp-ui-assets": {
-      "version": "4.18.0",
-      "resolved": "https://npm.pkg.github.com/download/@lana/b2c-mapp-ui-assets/4.18.0/0f7be1b4b17246269a8c57627812abe58fb531f2861eda7401f1b0c4410e4f6e",
-      "integrity": "sha512-guQx95GYU9SNflB7kw9BoecbDRcsU8JDourVaWD3R8IfvCdW0TZ4yedobf9ApmGZvOQP+SY+0SiUbYAHsErhug==",
+      "version": "4.22.0",
+      "resolved": "https://npm.pkg.github.com/download/@lana/b2c-mapp-ui-assets/4.22.0/b2aa8293e67dc660cc4fac88841fda539fcd094e0228f0bfc6af1bbb5f3a236f",
+      "integrity": "sha512-QJkwnpLFVEuHBr3QUO0KfGPX5bfXcXTebVD49M5YtJubOfgfXZUCjL1w421NwqxaExKqLC/ORewh5qIJDoek0Q==",
       "requires": {
         "core-js": "^3.7.0",
         "vue": "^2.6.11"
@@ -29488,9 +29488,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.15.1",
+  "version": "8.15.2",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@lana/b2c-mapp-ui-assets": "^4.18.0",
+    "@lana/b2c-mapp-ui-assets": "^4.22.0",
     "core-js": "^3.7.0",
     "fast-async": "^6.3.8",
     "libphonenumber-js": "^1.9.4",

--- a/src/components/AmountInput/AmountInput.js
+++ b/src/components/AmountInput/AmountInput.js
@@ -1,6 +1,8 @@
 import { CurrencyDirective, getValue, setValue, parse } from 'vue-currency-input';
 import ContentEditable from 'vue-contenteditable/src/contenteditable.vue';
 
+import { escapeRegExp } from '../../lib/regexHelper';
+
 const components = {
   ContentEditable,
 };
@@ -74,7 +76,9 @@ const computed = {
   },
   truncatedInputValue() {
     if (!this.inputValue) { return '0'; }
-    const result = this.inputValue.replace(this.currencySymbol, '').replaceAll(this.currencyGroup, '');
+    const symbolRegex = new RegExp(escapeRegExp(this.currencySymbol));
+    const groupRegex = new RegExp(escapeRegExp(this.currencyGroup), 'g');
+    const result = this.inputValue.replace(symbolRegex, '').replace(groupRegex, '');
     return result;
   },
   numericInputValue() {

--- a/src/lib/regexHelper.js
+++ b/src/lib/regexHelper.js
@@ -5,6 +5,8 @@ const validDateRegexp = /^(0?[1-9]|[12][0-9]|3[01])[/](0?[1-9]|1[012])[/]\d{4}$/
 const onlyDigitsRegexp = /\d+/;
 const singleDigitRegexp = /^\d+$/;
 
+const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 export {
   allSpacesRegexp,
   nonDigitSlashRegexp,
@@ -12,4 +14,5 @@ export {
   validDateRegexp,
   onlyDigitsRegexp,
   singleDigitRegexp,
+  escapeRegExp,
 };


### PR DESCRIPTION
## Description
`replaceAll` was not broadly accepted, specially for Huawei devices. Moved function from `replaceAll` to `replace` with global flag

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
