### PR TITLE
Button's click debounce

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.17.1",
+  "version": "8.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.17.1",
+  "version": "8.18.0",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,5 +1,10 @@
 import { MopIcon } from '@lana/b2c-mapp-ui-assets';
 
+const debounce = require('lodash.debounce');
+
+const DEBOUNCE_DELAY = 400;
+const DEBOUNCE_SETTINGS = { leading: true, trailing: false };
+
 const components = {
   MopIcon,
 };
@@ -25,6 +30,10 @@ const props = {
   disabled: Boolean,
   dropShadow: Boolean,
   id: String,
+  debounce: {
+    type: Boolean,
+    default: false,
+  },
 };
 
 const data = function () {
@@ -53,6 +62,10 @@ const computed = {
   },
   isLinkButton() {
     const result = (!!this.href || this.link);
+    return result;
+  },
+  clickMethod() {
+    const result = (this.debounce) ? debounce(this.onClick, DEBOUNCE_DELAY, DEBOUNCE_SETTINGS) : this.onClick;
     return result;
   },
 };

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -34,6 +34,9 @@ const defaultExample = () => ({
     dropShadow: {
       default: boolean('Has Drop Shadow?', false),
     },
+    debounce: {
+      default: boolean('Has debounce?', false),
+    },
     href: {
       default: text('href', ''),
     },
@@ -59,6 +62,7 @@ const defaultExample = () => ({
                   :loading-text="loadingText"
                   :drop-shadow="dropShadow"
                   :disabled="disabled"
+                  :debounce="debounce"
                   @click="onClick"
           >
             {{ contents }}

--- a/src/components/Button/Button.test.js
+++ b/src/components/Button/Button.test.js
@@ -1,9 +1,14 @@
+/* eslint-disable import/first */
 import { render, fireEvent } from '@testing-library/vue';
 import { mount } from '@vue/test-utils';
+
+jest.mock('lodash.debounce', () => jest.fn((fn) => fn));
 
 import Button from './Button.vue';
 import ButtonTestWrapper from './UnitTestWrappers/ButtonTestWrapper.vue';
 import { silenceDeprecationErrorsAndInnerComponentWarnings } from '../../lib/testUtils';
+
+const debounce = require('lodash.debounce');
 
 describe('Button unit test', () => {
   beforeAll(() => {
@@ -72,6 +77,13 @@ describe('Button unit test', () => {
       fireEvent.click(button);
       const clicked = emitted().click;
       expect(clicked).toBeTruthy();
+    });
+
+    it('Should call debounce when its clicked', () => {
+      const { getByTestId } = render(Button, { propsData: { type: 'primary', loading: false, debounce: true } });
+      const button = getByTestId('button-button');
+      fireEvent.click(button);
+      expect(debounce).toHaveBeenCalled();
     });
   });
 

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -7,7 +7,7 @@
              :href="href"
              :disabled="disabled"
              :data-testid="dataTestIdToUse"
-             @click="onClick"
+             @click="clickMethod"
              @touchStart="toggleIsPressed"
              @touchEnd="toggleIsPressed"
   >

--- a/src/components/CallToActionScreen/CallToActionScreen.js
+++ b/src/components/CallToActionScreen/CallToActionScreen.js
@@ -31,6 +31,10 @@ const props = {
     type: String,
     default: '',
   },
+  debounce: {
+    type: Boolean,
+    default: false,
+  },
 };
 
 const methods = {

--- a/src/components/CallToActionScreen/CallToActionScreen.vue
+++ b/src/components/CallToActionScreen/CallToActionScreen.vue
@@ -9,7 +9,8 @@
         <slot/>
       </Wrapper>
     </ScrollWrapper>
-    <WrappedButton :data-testid="dataTestId" @click="onClick"> {{ buttonText }} </WrappedButton>
+    <slot name="secondaryAction"/>
+    <WrappedButton :data-testid="dataTestId" :debounce="debounce" @click="onClick"> {{ buttonText }} </WrappedButton>
   </Screen>
 </template>
 

--- a/src/components/ForwardButton/ForwardButton.js
+++ b/src/components/ForwardButton/ForwardButton.js
@@ -15,6 +15,10 @@ const props = {
   disabled: Boolean,
   id: String,
   name: String,
+  debounce: {
+    type: Boolean,
+    default: false,
+  },
 };
 
 const methods = {

--- a/src/components/ForwardButton/ForwardButton.vue
+++ b/src/components/ForwardButton/ForwardButton.vue
@@ -5,6 +5,7 @@
             :name="name"
             :disabled="disabled"
             drop-shadow
+            :debounce="debounce"
             @click="onClick"
     >
       <ChevronRightIcon class="forward-icon"/>

--- a/src/components/WrappedButton/WrappedButton.js
+++ b/src/components/WrappedButton/WrappedButton.js
@@ -25,6 +25,10 @@ const props = {
     default: 'Cargando...',
   },
   disabled: Boolean,
+  debounce: {
+    type: Boolean,
+    default: false,
+  },
   id: String,
   name: String,
 };

--- a/src/components/WrappedButton/WrappedButton.vue
+++ b/src/components/WrappedButton/WrappedButton.vue
@@ -7,6 +7,7 @@
             :loading="loading"
             :loading-text="loadingText"
             :disabled="disabled"
+            :debounce="debounce"
             @click="onClick"
     >
       <slot/>


### PR DESCRIPTION
## Description
Added the possibility to accept debounce as parameter to make a delay on multiclicks for Button, WrappedButton, CallToAction, ForwardButton

## Testing
Add `debounce` parameter to one of the component mentioned before and  try to click multiple times, only on `click` event will be emitter

## Checks
- [x] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [x] **MINOR** adds functionality in a backwards-compatible manner.
- [ ] **PATCH** backwards-compatible bug fixes.
