### PR TITLE
Fix Carousel items setter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.18.0",
+  "version": "8.18.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3334,9 +3334,9 @@
       }
     },
     "@lana/b2c-mapp-ui-assets": {
-      "version": "4.22.0",
-      "resolved": "https://npm.pkg.github.com/download/@lana/b2c-mapp-ui-assets/4.22.0/b2aa8293e67dc660cc4fac88841fda539fcd094e0228f0bfc6af1bbb5f3a236f",
-      "integrity": "sha512-QJkwnpLFVEuHBr3QUO0KfGPX5bfXcXTebVD49M5YtJubOfgfXZUCjL1w421NwqxaExKqLC/ORewh5qIJDoek0Q==",
+      "version": "4.27.0",
+      "resolved": "https://npm.pkg.github.com/download/@lana/b2c-mapp-ui-assets/4.27.0/520619153a6dd4bc8502d3e3400945013139538b0319518c68e0166921dc8de4",
+      "integrity": "sha512-bVatuHg5xJxKHwXPgEDNPius8odf/MXaQOhaMCwdCbDHdIQMRReDNrYtpAkepD2D2pZjj9Fw92KaNcP3RB+RGQ==",
       "requires": {
         "core-js": "^3.7.0",
         "vue": "^2.6.11"
@@ -27792,11 +27792,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/vue-frag/-/vue-frag-1.1.5.tgz",
       "integrity": "sha512-g+PP9pjW1gnrmPjy2Sa5jK/bfxYHK8Hgt1sVs/Y/7KT+srGJUwtGNwXNTUvWv/zJ2yGcvJVEH98eIrICyZX9Ng=="
-    },
-    "vue-fragment": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/vue-fragment/-/vue-fragment-1.5.2.tgz",
-      "integrity": "sha512-KEW0gkeNOLJjtXN4jqJhTazez5jtrwimHkE5Few/VxblH4F9EcvJiEsahrV5kg5uKd5U8du4ORKS6QjGE0piYA=="
     },
     "vue-hot-reload-api": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.18.0",
+  "version": "8.18.1",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@lana/b2c-mapp-ui-assets": "^4.22.0",
+    "@lana/b2c-mapp-ui-assets": "^4.27.0",
     "core-js": "^3.7.0",
     "fast-async": "^6.3.8",
     "libphonenumber-js": "^1.9.4",

--- a/src/components/Carousel/Carousel.js
+++ b/src/components/Carousel/Carousel.js
@@ -65,7 +65,7 @@ const methods = {
       }
       return accumulator;
     }, []);
-    const result = (items.length) ? items : this.$refs.carousel.children;
+    const result = (items.length) ? items : [...this.$refs.carousel.children];
     return result;
   },
   async setItems() {
@@ -108,7 +108,8 @@ const methods = {
   },
   handleScroll(event) {
     const { scrollLeft } = event.target;
-    const index = this.items.findIndex(({ offsetLeft: itemOffsetLeft }) => (itemOffsetLeft === scrollLeft));
+    const roundedScrollLeft = Math.round(scrollLeft);
+    const index = this.items.findIndex(({ offsetLeft: itemOffsetLeft }) => (itemOffsetLeft === roundedScrollLeft));
     if (index < 0) { return; }
     this.currentIndex = index;
   },


### PR DESCRIPTION
## Description
Change from HTMLCollection getter to an Array definition, so `findIndex` won't fail 

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
