### PR TITLE
Fix Carousel navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.18.1",
+  "version": "8.18.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.18.1",
+  "version": "8.18.2",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/Carousel/Carousel.js
+++ b/src/components/Carousel/Carousel.js
@@ -39,6 +39,7 @@ const data = function () {
     currentIndex: this.value,
     initialX: 0,
     scrollLeft: 0,
+    destinationScrollLeft: null,
     isScrolling: false,
   };
 };
@@ -78,9 +79,10 @@ const methods = {
     this.setCurrentIndex(this.currentIndex + direction);
   }, SCROLL_DEBOUNCE),
   setCurrentIndex(index) {
-    if (!this.items[index]) {
+    if (!this.items[index] || index === this.currentIndex) {
       return;
     }
+    this.destinationScrollLeft = this.items[index].offsetLeft;
     this.currentIndex = index;
     this.$refs.carousel.scrollTo({
       left: this.items[index].offsetLeft,
@@ -111,6 +113,7 @@ const methods = {
     const roundedScrollLeft = Math.round(scrollLeft);
     const index = this.items.findIndex(({ offsetLeft: itemOffsetLeft }) => (itemOffsetLeft === roundedScrollLeft));
     if (index < 0) { return; }
+    if (this.destinationScrollLeft !== null && this.items[index].offsetLeft !== this.destinationScrollLeft) { return; }
     this.currentIndex = index;
   },
 };
@@ -121,6 +124,7 @@ const watch = {
   },
   currentIndex() {
     this.$emit('input', this.currentIndex);
+    this.destinationScrollLeft = null;
   },
 };
 

--- a/src/components/Carousel/Carousel.vue
+++ b/src/components/Carousel/Carousel.vue
@@ -56,7 +56,7 @@
         <button v-for="index in items.length"
                 :key="index"
                 :data-testid="`${dataTestId}-navigation-item`"
-                @click="setCurrentIndex(index -1)"
+                @click="setCurrentIndex(index - 1)"
         >
           <slot v-if="(index - 1) !== currentIndex"
                 name="navigationItem"


### PR DESCRIPTION
## Description
Sometimes the navigation is overridden by the watcher of `currentIndex` and doesn't allow the user to scroll to the desire slide. With the help of a `destinationScrollLeft` every intermediary index is not considered

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
