### PR TITLE
Carousel resize observer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.19.0",
+  "version": "8.19.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.19.0",
+  "version": "8.19.1",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/Carousel/Carousel.js
+++ b/src/components/Carousel/Carousel.js
@@ -41,6 +41,7 @@ const data = function () {
     scrollLeft: 0,
     destinationScrollLeft: null,
     isScrolling: false,
+    resizeObserver: null,
   };
 };
 
@@ -130,6 +131,14 @@ const methods = {
     this.destinationScrollLeft = null;
     this.currentIndex = index;
   },
+  onObserverEvent() {
+    this.updateScroll(this.currentIndex);
+  },
+  initObserver() {
+    const resizeObserver = new ResizeObserver(this.onObserverEvent);
+    resizeObserver.observe(this.$refs.carousel);
+    this.resizeObserver = resizeObserver;
+  },
 };
 
 const watch = {
@@ -145,11 +154,13 @@ const mounted = function () {
   this.setItems();
   document.addEventListener('mousemove', this.handleGestureMove);
   document.addEventListener('mouseup', this.handleGestureEnd);
+  this.initObserver();
 };
 
 const beforeDestroy = function () {
   document.removeEventListener('mousemove', this.handleGestureMove);
   document.removeEventListener('mouseup', this.handleGestureEnd);
+  if (this.resizeObserver) { this.resizeObserver.unobserve(this.$refs.carousel); }
 };
 
 const Carousel = {

--- a/src/components/Carousel/Carousel.test.js
+++ b/src/components/Carousel/Carousel.test.js
@@ -11,6 +11,12 @@ const waitForDomUpdate = async (wrapper) => {
   await wrapper.vm.$forceUpdate();
 };
 
+window.ResizeObserver = window.ResizeObserver || jest.fn().mockImplementation(() => ({
+  disconnect: jest.fn(),
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+}));
+
 describe('Carousel unit test', () => {
   beforeAll(() => {
     silenceDeprecationErrorsAndInnerComponentWarnings(jest);


### PR DESCRIPTION
## Description
Fix Carousel slide selection being wrong after resizing


## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
