### PR TITLE
Fix AmountInput locale parse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.21.0",
+  "version": "8.21.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.21.0",
+  "version": "8.21.1",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/AmountInput/AmountInput.js
+++ b/src/components/AmountInput/AmountInput.js
@@ -28,10 +28,6 @@ const props = {
     type: [String],
     default: 'es-MX',
   },
-  decimal: {
-    type: Number,
-    default: 2,
-  },
   id: {
     type: String,
     default: 'amount-input-id',
@@ -46,8 +42,8 @@ const props = {
 const data = function () {
   return {
     isFocused: false,
-    inputValue: `${this.value || 0}`,
-    currencyValue: `${this.value || 0}`,
+    inputValue: `${this.value || '0'}`,
+    currencyValue: `${this.value || '0'}`,
   };
 };
 
@@ -158,30 +154,32 @@ const watch = {
   inputValue() {
     this.fitTextContainer();
     if (!this.isFocused) { return; }
-    setValue(this.$refs.input, parse(this.numericInputValue));
+    const newValue = parse(this.numericInputValue, { ...this.currencyOptions, currency: this.currency });
+    setValue(this.$refs.input, newValue);
   },
   currencyValue() {
     this.emitInputEvent();
-    if (!this.isFocused) {
-      this.inputValue = this.currencyValue;
-    }
+    if (this.isFocused) { return; }
+    this.inputValue = `${this.currencyValue}`;
   },
   value() {
     if (!this.value) { return; }
-    setValue(this.$refs.input, parse(this.value || '0'));
+    const newValue = parse(this.value || '0', { ...this.currencyOptions, currency: this.currency });
+    setValue(this.$refs.input, newValue);
     if (this.isFocused) { return; }
     this.inputValue = this.currencyValue;
   },
   isFocused() {
     if (this.disabled || this.readonly) { return; }
+    const newValue = parse(this.numericInputValue, { ...this.currencyOptions, currency: this.currency });
     if (!this.isFocused) {
-      if (!parse(this.numericInputValue)) {
+      if (!newValue) {
         this.currencyValue = '0';
       }
-      this.inputValue = this.currencyValue;
+      this.inputValue = `${this.currencyValue}`;
       return;
     }
-    this.inputValue = `${parse(this.numericInputValue)}`;
+    this.inputValue = `${newValue}`;
   },
 };
 

--- a/src/components/AmountInput/AmountInput.stories.js
+++ b/src/components/AmountInput/AmountInput.stories.js
@@ -78,6 +78,7 @@ const defaultExample = (args, { argTypes }) => ({
                    :key="startFocused"
                    ref="field"
                    :currency="currency"
+                   :locale="locale"
                    :disabled="disabled"
                    :readonly="readonly"
                    :start-focused="startFocused"

--- a/src/components/AmountInput/AmountInput.test.js
+++ b/src/components/AmountInput/AmountInput.test.js
@@ -13,7 +13,7 @@ describe('AmountInput unit test', () => {
 
   it('Should apply given value', async () => {
     const newValue = '123';
-    const wrapper = mount(AmountInput, { propsData: { ...defaultProps, value: newValue, decimal: 0 } });
+    const wrapper = mount(AmountInput, { propsData: { ...defaultProps, value: newValue } });
     await wrapper.vm.$nextTick();
     wrapper.vm.$options.watch.currencyValue.call(wrapper.vm, newValue);
     await wrapper.vm.$nextTick();
@@ -38,12 +38,23 @@ describe('AmountInput unit test', () => {
 
   it('Should provide current input value in the input event when value changed', async () => {
     const givenValue = '123';
-    const wrapper = mount(AmountInput, { propsData: { ...defaultProps, value: '', decimal: 0 } });
+    const wrapper = mount(AmountInput, { propsData: { ...defaultProps, value: '' } });
     await wrapper.vm.$nextTick();
     wrapper.find('input').setValue(givenValue);
     await wrapper.vm.$nextTick();
     const inputEventValue = wrapper.emitted().input[0][0];
     const inputEmittedValueIsCurrent = (inputEventValue.includes(givenValue));
+    expect(inputEmittedValueIsCurrent).toBeTruthy();
+  });
+
+  it('Should provide correct value in the input event with thousands value with CLP currency', async () => {
+    const givenValue = '10000';
+    const wrapper = mount(AmountInput, { propsData: { ...defaultProps, value: '', currency: 'CLP', locale: 'es-CL' } });
+    await wrapper.vm.$nextTick();
+    wrapper.find('input').setValue(givenValue);
+    await wrapper.vm.$nextTick();
+    const inputEventValue = wrapper.emitted().input[0][0];
+    const inputEmittedValueIsCurrent = (inputEventValue.includes('10,000'));
     expect(inputEmittedValueIsCurrent).toBeTruthy();
   });
 


### PR DESCRIPTION
## Description
AmountInput was not correctly handling thousand separator for CLP, as `10.000` became `10` and `1.000.000` became `null`. `parse` must include options to handle that.

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
