### PR TITLE
Fix PhoneNumberField validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.21.1",
+  "version": "8.21.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.21.1",
+  "version": "8.21.2",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/PhoneNumberField/PhoneNumberField.js
+++ b/src/components/PhoneNumberField/PhoneNumberField.js
@@ -3,7 +3,7 @@ import { AsYouType, getCountryCallingCode, getCountries } from 'libphonenumber-j
 import FormField from '../FormField/FormField.vue';
 import TextParagraph from '../TextParagraph/TextParagraph.vue';
 import phoneNumberMetadata from '../../../data/libphonenumber-metadata.min.json';
-import { onlyDigitsRegexp, allSpacesRegexp } from '../../lib/regexHelper';
+import { onlyDigitsRegexp, nonDigitRegexp } from '../../lib/regexHelper';
 
 const availableCountryCodes = getCountries(phoneNumberMetadata);
 
@@ -91,8 +91,8 @@ const methods = {
     this.$refs.field.focus();
   },
   isPhoneNumberValid() {
-    const inputValueWithoutSpaces = this.inputValue.replace(allSpacesRegexp, '');
-    if (this.maxPhoneNumberLength && (inputValueWithoutSpaces.length > this.maxPhoneNumberLength)) { return false; }
+    const cleanedInputValue = this.inputValue.replace(nonDigitRegexp, '');
+    if (this.maxPhoneNumberLength && (cleanedInputValue.length > this.maxPhoneNumberLength)) { return false; }
     const asYouType = new AsYouType(this.countryCode, phoneNumberMetadata);
     asYouType.input((this.inputValue || ''));
     const result = asYouType.isPossible();

--- a/src/components/PhoneNumberField/PhoneNumberField.test.js
+++ b/src/components/PhoneNumberField/PhoneNumberField.test.js
@@ -47,6 +47,12 @@ describe('UI/forms/PhoneNumberField', () => {
     expect(noErrorLabel).toBeTruthy();
   });
 
+  it('Should not show error label if given value is valid and has parenthesis', () => {
+    const { getByTestId } = render(PhoneNumberField, { propsData: { ...defaultProps, countryCode: 'CL', value: '223344556' } });
+    const noErrorLabel = !getByTestId('phone-field-label').className.includes('error');
+    expect(noErrorLabel).toBeTruthy();
+  });
+
   it('Should show error label if given value is NOT valid', () => {
     const { getByTestId } = render(PhoneNumberField, { propsData: { ...defaultProps, errorLabel: 'Error!', value: '551234123234324' } });
     const errorLabel = getByTestId('phone-field-container').className.includes('error');


### PR DESCRIPTION
## Description
Fix validation for PhoneNumberField, as with some numbers that add parenthesis `()` it is considered bad numbers

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
