### PR TITLE
Fix animation error for tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.27.2",
+  "version": "8.27.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.27.2",
+  "version": "8.27.3",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/LinearProgress/LinearProgress.js
+++ b/src/components/LinearProgress/LinearProgress.js
@@ -49,18 +49,22 @@ const computed = {
 
 const methods = {
   startAnimation() {
-    const { bar, circle } = this.$refs;
-    const barAnimation = [
-      { width: 0 },
-      { width: `${this.progressPercentage}%` },
-    ];
-    const circleAnimation = [
-      { left: 0 },
-      { left: `${this.progressPercentage}%` },
-    ];
-    const animation = bar.animate(barAnimation, { duration: this.animationDuration, iterations: (this.circularAnimation) ? Infinity : 1 });
-    circle.animate(circleAnimation, { duration: this.animationDuration, iterations: (this.circularAnimation) ? Infinity : 1 });
-    animation.onfinish = this.emitEventFinish;
+    try {
+      const { bar, circle } = this.$refs;
+      const barAnimation = [
+        { width: 0 },
+        { width: `${this.progressPercentage}%` },
+      ];
+      const circleAnimation = [
+        { left: 0 },
+        { left: `${this.progressPercentage}%` },
+      ];
+      const animation = bar.animate(barAnimation, { duration: this.animationDuration, iterations: (this.circularAnimation) ? Infinity : 1 });
+      circle.animate(circleAnimation, { duration: this.animationDuration, iterations: (this.circularAnimation) ? Infinity : 1 });
+      animation.onfinish = this.emitEventFinish;
+    } catch (error) {
+      this.$emit('error', error);
+    }
   },
   emitEventFinish(event) {
     this.$emit('animationend', event);

--- a/src/components/LinearProgress/LinearProgress.test.js
+++ b/src/components/LinearProgress/LinearProgress.test.js
@@ -28,4 +28,10 @@ describe('LinearProgress unit test', () => {
     const circle = wrapper.find('div[data-testid="linear-progress-circle-bar"]');
     expect(circle.element.style.display).toContain('none');
   });
+
+  it('Should send error for test animation', async () => {
+    const wrapper = mount(LinearProgress, { propsData: { ...defaultProps, progress: 100, animate: true, animationDuration: 1 } });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted().error).toBeTruthy();
+  });
 });

--- a/src/components/Progress/Progress.js
+++ b/src/components/Progress/Progress.js
@@ -72,20 +72,24 @@ const computed = {
 
 const methods = {
   startAnimation() {
-    const { bar, circle, outsideBorder, insideBorder } = this.$refs;
-    const barAnimation = [
-      { transform: 'rotate(45deg)' },
-      { transform: `rotate(${45 + (this.progressPercentage * 1.8)}deg)` },
-    ];
-    const circleAnimation = [
-      { transform: 'rotate(0deg)' },
-      { transform: `rotate(${(this.progressPercentage * 1.8)}deg)` },
-    ];
-    const animation = bar.animate(barAnimation, { duration: this.animationDuration, iterations: (this.circularAnimation) ? Infinity : 1 });
-    outsideBorder.animate(barAnimation, { duration: this.animationDuration, iterations: (this.circularAnimation) ? Infinity : 1 });
-    insideBorder.animate(barAnimation, { duration: this.animationDuration, iterations: (this.circularAnimation) ? Infinity : 1 });
-    circle.animate(circleAnimation, { duration: this.animationDuration, iterations: (this.circularAnimation) ? Infinity : 1 });
-    animation.onfinish = this.emitEventFinish;
+    try {
+      const { bar, circle, outsideBorder, insideBorder } = this.$refs;
+      const barAnimation = [
+        { transform: 'rotate(45deg)' },
+        { transform: `rotate(${45 + (this.progressPercentage * 1.8)}deg)` },
+      ];
+      const circleAnimation = [
+        { transform: 'rotate(0deg)' },
+        { transform: `rotate(${(this.progressPercentage * 1.8)}deg)` },
+      ];
+      const animation = bar.animate(barAnimation, { duration: this.animationDuration, iterations: (this.circularAnimation) ? Infinity : 1 });
+      outsideBorder.animate(barAnimation, { duration: this.animationDuration, iterations: (this.circularAnimation) ? Infinity : 1 });
+      insideBorder.animate(barAnimation, { duration: this.animationDuration, iterations: (this.circularAnimation) ? Infinity : 1 });
+      circle.animate(circleAnimation, { duration: this.animationDuration, iterations: (this.circularAnimation) ? Infinity : 1 });
+      animation.onfinish = this.emitEventFinish;
+    } catch (error) {
+      this.$emit('error', error);
+    }
   },
   emitEventFinish(event) {
     this.$emit('animationend', event);

--- a/src/components/Progress/Progress.test.js
+++ b/src/components/Progress/Progress.test.js
@@ -75,4 +75,10 @@ describe('Progress unit test', () => {
     const customDescription = wrapper.find('p[data-testid="custom-description"]');
     expect(customDescription).toBeTruthy();
   });
+
+  it('Should send error for test animation', async () => {
+    const wrapper = mount(Progress, { propsData: { ...defaultProps, progress: 100, animate: true, animationDuration: 1 } });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted().error).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Description
Animation API isn't available on tests, so when animated the tests are failing

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
