### PR TITLE
ConfirmationModalDialog extra slot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.28.1",
+  "version": "8.29.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.28.1",
+  "version": "8.29.0",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/ConfirmationModalDialog/ConfirmationModalDialog.stories.js
+++ b/src/components/ConfirmationModalDialog/ConfirmationModalDialog.stories.js
@@ -1,5 +1,6 @@
 import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { CloseIcon } from '@lana/b2c-mapp-ui-assets';
 
 import ConfirmationModalDialog from './ConfirmationModalDialog.vue';
 
@@ -229,11 +230,68 @@ const withConfirmButtonDisabled = () => ({
     </div>
   `,
 });
+
+const withCustomActionButton = () => ({
+  components: {
+    ConfirmationModalDialog,
+    CloseIcon,
+  },
+  data() {
+    return {
+      isShowing: false,
+    };
+  },
+  computed: {
+    showHideTitle() {
+      if (this.isShowing) { return 'Hide'; }
+      return 'Show';
+    },
+  },
+  methods: {
+    onDismiss: action('Dismissed!'),
+    onConfirm: action('Confirmed!'),
+    onClose: action('Closed!'),
+    toggleIsShowing() {
+      this.isShowing = !this.isShowing;
+    },
+  },
+  template: `
+    <div style="margin: 10px 50px 10px 50px;">
+      <h2><strong>ConfirmationModalDialog:</strong>&nbsp;Custom action button binded to "onDismiss" example.</h2>
+      <hr>
+      <div style="margin-top: 20px; width: 100px">
+        <ConfirmationModalDialog v-model="isShowing"
+                                 title="Custom action button binded to 'onDismiss' Example"
+                                 confirm-button-text=""
+                                 dismiss-button-text=""
+                                 @dismiss="onDismiss"
+                                 @confirm="onConfirm"
+                                 @close="onClose"
+        >
+          <template v-slot:extraActions="{ onDismiss }">
+            <button style="position: absolute; right: 10%; top: 10%;" @click="onDismiss"><CloseIcon width="18" /></button>
+          </template>
+          <div style="margin: 20px">
+            This is some <strong>custom</strong> content
+          </div>
+        </ConfirmationModalDialog>
+      </div>
+      <div style="margin-top: 20px;">
+        Bound value: {{ isShowing }}
+      </div>
+      <div style="margin-top: 20px; display: flex; flex-direction: row; width: 100%; justify-content: center">
+        <button style="font-size: 20px; color: blue;" @click="toggleIsShowing">{{ showHideTitle }} Dialog</button>
+      </div>
+    </div>
+  `,
+});
+
 export {
   defaultExample,
   withCustomContent,
   withDismissButtonDisabled,
   withConfirmButtonDisabled,
+  withCustomActionButton,
 };
 
 export default ConfirmationModalDialogStories;

--- a/src/components/ConfirmationModalDialog/ConfirmationModalDialog.test.js
+++ b/src/components/ConfirmationModalDialog/ConfirmationModalDialog.test.js
@@ -67,6 +67,18 @@ describe('ConfirmationmodalDialog unit test', () => {
     expect(childrenIsShown).toBeTruthy();
   });
 
+  it('Should show custom action', () => {
+    const { getByTestId } = render(
+      ConfirmationModalDialog,
+      {
+        slots: { extraActions: '<a data-testid="custom-action">x</a>' },
+        propsData: { ...defaultProps },
+      },
+    );
+    const customTitleVisible = getByTestId('custom-action');
+    expect(customTitleVisible).toBeTruthy();
+  });
+
   describe('Confirm actions behavior', () => {
     it('Should show action-confirm button when confirm is given', () => {
       const { getByTestId } = render(ConfirmationModalDialog, { propsData: { ...defaultProps } });
@@ -158,6 +170,20 @@ describe('ConfirmationmodalDialog unit test', () => {
       await wrapper.vm.$nextTick();
       const closeEventEmitted = wrapper.emitted().close;
       expect(closeEventEmitted).toBeTruthy();
+    });
+
+    it('Should emit an event when dismiss is given by extra slot and action-dismiss is clicked', () => {
+      const { getByTestId, emitted } = render(
+        ConfirmationModalDialog,
+        {
+          scopedSlots: { extraActions: '<a data-testid="custom-action" @click="props.onDismiss">x</a>' },
+          propsData: { ...defaultProps },
+        },
+      );
+      const dismissCTA = getByTestId('custom-action');
+      fireEvent.click(dismissCTA);
+      const clickEvent = emitted().dismiss;
+      expect(clickEvent).toBeTruthy();
     });
   });
 });

--- a/src/components/ConfirmationModalDialog/ConfirmationModalDialog.vue
+++ b/src/components/ConfirmationModalDialog/ConfirmationModalDialog.vue
@@ -3,6 +3,7 @@
            :class="{ visible: isShowing }"
            :data-testid="`${dataTestId}-section`"
   >
+    <slot v-bind="{ onDismiss, onConfirm }" name="extraActions" />
     <div class="dialog" :data-testid="`${dataTestId}-content`">
       <Heading v-if="title"
                class="title"


### PR DESCRIPTION
## Description
Added a new slot for ConfirmationModalDialog for custom purposes, like adding a custom close button 

## Screenshots/Captures
![custom close dialog](https://user-images.githubusercontent.com/1281392/127005447-e00666f5-dbe1-4c52-9632-6b17b7247009.png)

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [x] **MINOR** adds functionality in a backwards-compatible manner.
- [ ] **PATCH** backwards-compatible bug fixes.
