### PR TITLE
Fix ContentEditable sfc import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.30.1",
+  "version": "8.30.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "8.30.1",
+  "version": "8.30.2",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/AmountInput/AmountInput.js
+++ b/src/components/AmountInput/AmountInput.js
@@ -1,10 +1,11 @@
-import Vue from 'vue';
 import { CurrencyDirective, getValue, setValue, parse } from 'vue-currency-input';
-import contenteditable from 'vue-contenteditable';
+import ContentEditable from 'vue-contenteditable/src/contenteditable.vue';
 
 import { escapeRegExp } from '../../lib/regexHelper';
 
-Vue.use(contenteditable);
+const components = {
+  ContentEditable,
+};
 
 const directives = {
   currency: CurrencyDirective,
@@ -187,6 +188,7 @@ const mounted = function () {
 };
 
 const AmountInput = {
+  components,
   directives,
   props,
   computed,

--- a/src/components/AmountInput/AmountInput.vue
+++ b/src/components/AmountInput/AmountInput.vue
@@ -4,7 +4,7 @@
          :data-testid="`${dataTestId}-container`"
     >
       <span class="symbol">{{ currencySymbol }}</span>
-      <contenteditable :id="inputId"
+      <ContentEditable :id="inputId"
                        ref="content"
                        v-model="inputValue"
                        tag="div"

--- a/src/main.js
+++ b/src/main.js
@@ -1,12 +1,9 @@
 import Vue from 'vue';
-import contenteditable from 'vue-contenteditable';
 
 import App from './App.vue';
 
 Vue.config.productionTip = false;
 Vue.config.devtools = false;
-
-Vue.use(contenteditable);
 
 const appRootSelector = '#app';
 const vueOptions = {


### PR DESCRIPTION
## Description
Rollback to previous import method of ContentEditable regarding sfc standard recommendation

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
