### PR TITLE
Fix css injection being stripped on tree shaking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lana/b2c-mapp-ui",
-      "version": "9.0.0",
+      "version": "9.0.1",
       "license": "ISC",
       "dependencies": {
         "@lana/b2c-mapp-ui-assets": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/lib/libInjectCss.js
+++ b/src/lib/libInjectCss.js
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 
 const fileRegex = /\.(scss)$/;
 
-const injectCode = (code) => `function styleInject(css,ref){if(ref===void 0){ref={}}var insertAt=ref.insertAt;if(!css||typeof document==="undefined"){return}var head=document.head||document.getElementsByTagName("head")[0];var style=document.createElement("style");style.type="text/css";if(insertAt==="top"){if(head.firstChild){head.insertBefore(style,head.firstChild)}else{head.appendChild(style)}}else{head.appendChild(style)}if(style.styleSheet){style.styleSheet.cssText=css}else{style.appendChild(document.createTextNode(css))}};/*#__PURE__*/styleInject(\`${code}\`)`;
+const injectCode = (code) => `function styleInject(css,ref){if(ref===void 0){ref={}}var insertAt=ref.insertAt;if(!css||typeof document==="undefined"){return}var head=document.head||document.getElementsByTagName("head")[0];var style=document.createElement("style");style.type="text/css";if(insertAt==="top"){if(head.firstChild){head.insertBefore(style,head.firstChild)}else{head.appendChild(style)}}else{head.appendChild(style)}if(style.styleSheet){style.styleSheet.cssText=css}else{style.appendChild(document.createTextNode(css))}};styleInject(\`${code}\`)`;
 const template = 'console.warn("__INJECT__")';
 
 let viteConfig;


### PR DESCRIPTION
## Description
The `/*#__PURE__*/` was incorrectly removing the css out of the bundles on the tree shaking on the manual injection

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
