### PR TITLE
Fix CallToActionScreen emits property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lana/b2c-mapp-ui",
-      "version": "9.1.0",
+      "version": "9.1.1",
       "license": "ISC",
       "dependencies": {
         "@lana/b2c-mapp-ui-assets": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/CallToActionScreen/CallToActionScreen.js
+++ b/src/components/CallToActionScreen/CallToActionScreen.js
@@ -14,6 +14,8 @@ const components = {
   ScrollWrapper,
 };
 
+const emits = ['click'];
+
 const props = {
   dataTestId: {
     type: String,
@@ -38,13 +40,14 @@ const props = {
 };
 
 const methods = {
-  onClick() {
-    this.$emit('click');
+  onClick(event) {
+    this.$emit('click', event);
   },
 };
 
 const CallToActionScreen = {
   components,
+  emits,
   props,
   methods,
 };

--- a/src/components/CallToActionScreen/CallToActionScreen.test.js
+++ b/src/components/CallToActionScreen/CallToActionScreen.test.js
@@ -15,4 +15,23 @@ describe('CallToActionScreen unit test ', () => {
     const clickEventEmitted = wrapper.emitted().click;
     expect(clickEventEmitted).toBeTruthy();
   });
+
+  it('Should not emit click event when button inside slot is clicked', async () => {
+    const wrapper = mount(
+      CallToActionScreen,
+      {
+        props: { ...defaultProps },
+        slots: {
+          secondaryAction: {
+            methods: { onClick() { return jest.fn(); } },
+            template: '<button data-testid="inner-button" @click="onClick">button</button>',
+          },
+        },
+      },
+    );
+    const button = wrapper.find('button[data-testid="inner-button"]');
+    await button.trigger('click');
+    const clickEventEmitted = wrapper.emitted().click;
+    expect(clickEventEmitted).toBeFalsy();
+  });
 });


### PR DESCRIPTION
## Description
Fix event handler of CallToActionScreen by adding `emits` property as the were not correctly handled

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
