### PR TITLE
Fix slot content detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "9.4.1",
+  "version": "9.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lana/b2c-mapp-ui",
-      "version": "9.4.1",
+      "version": "9.4.2",
       "license": "ISC",
       "dependencies": {
         "@lana/b2c-mapp-ui-assets": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "9.4.1",
+  "version": "9.4.2",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/ActionItem/ActionItem.js
+++ b/src/components/ActionItem/ActionItem.js
@@ -1,3 +1,5 @@
+import { Comment } from 'vue';
+
 import TextParagraph from '../TextParagraph/TextParagraph.vue';
 
 const errorStatuses = [
@@ -32,6 +34,10 @@ const props = {
 const emits = ['click'];
 
 const computed = {
+  hasDefaultSlot() {
+    const result = this.$slots.default && this.$slots.default().findIndex((node) => (node.type !== Comment)) !== -1;
+    return result;
+  },
   hasErrorStatus() {
     if (!this.status) { return; }
     const result = errorStatuses.includes(this.status.toLowerCase());

--- a/src/components/ActionItem/ActionItem.stories.js
+++ b/src/components/ActionItem/ActionItem.stories.js
@@ -61,7 +61,7 @@ const defaultExample = (args, { argTypes }) => ({
                   :status="status"
                   @click="onClick"
       >
-        <RenderString :string="defaultSlot" />
+        <RenderString v-if="defaultSlot" :string="defaultSlot" />
       </ActionItem>
     </ul>
   `,
@@ -136,6 +136,14 @@ const fullExample = (args, { argTypes }) => ({
             <div>
               <DocumentFilledIcon/>
             </div>
+          </ActionItem>
+          <ActionItem :title="title"
+                      :description="description"
+                      :highlight="highlight"
+                      :status="status"
+                      @click="onClick"
+          >
+            <div v-if="false"/>
           </ActionItem>
         </ul>
   `,

--- a/src/components/ActionItem/ActionItem.vue
+++ b/src/components/ActionItem/ActionItem.vue
@@ -3,7 +3,7 @@
       class="item"
       @click="onClick"
   >
-    <div v-if="$slots.default"
+    <div v-if="hasDefaultSlot"
          class="media"
          :data-testid="`${dataTestId}-mediacolor`"
     >

--- a/src/components/BoxContentItem/BoxContentItem.js
+++ b/src/components/BoxContentItem/BoxContentItem.js
@@ -35,12 +35,16 @@ const data = function () {
 };
 
 const computed = {
+  hasDefaultSlot() {
+    const result = this.$slots.default && this.$slots.default().findIndex((node) => (node.type !== Comment)) !== -1;
+    return result;
+  },
   hasIcon() {
     const result = (this.success);
     return result;
   },
   hasMetaText() {
-    const result = (this.metaText || this.$slots.customMetaText);
+    const result = (this.metaText || this.$slots.customMetaText());
     return result;
   },
 };

--- a/src/components/BoxContentItem/BoxContentItem.vue
+++ b/src/components/BoxContentItem/BoxContentItem.vue
@@ -7,7 +7,7 @@
       @touchStart="toggleIsPressed"
       @touchEnd="toggleIsPressed"
   >
-    <div v-if="$slots.default"
+    <div v-if="hasDefaultSlot"
          class="media"
          :data-testid="`${dataTestId}-media-icon`"
     >

--- a/src/components/Carousel/Carousel.vue
+++ b/src/components/Carousel/Carousel.vue
@@ -26,7 +26,7 @@
               @click="debouncedChangeRenderedItem(-1)"
       >
         <slot v-if="arrowIcons" name="leftArrowIcon">
-          <ChevronLeftIcon v-if="!$slots.leftArrowIcon" class="icon"/>
+          <ChevronLeftIcon class="icon"/>
         </slot>
       </button>
       <button v-show="isNextAvailable"
@@ -38,7 +38,7 @@
               @click="debouncedChangeRenderedItem(1)"
       >
         <slot v-if="arrowIcons" name="rightArrowIcon">
-          <ChevronRightIcon v-if="!$slots.rightArrowIcon" class="icon"/>
+          <ChevronRightIcon class="icon"/>
         </slot>
       </button>
     </slot>

--- a/src/components/ContentItem/ContentItem.js
+++ b/src/components/ContentItem/ContentItem.js
@@ -44,12 +44,16 @@ const data = function () {
 };
 
 const computed = {
+  hasDefaultSlot() {
+    const result = this.$slots.default && this.$slots.default().findIndex((node) => (node.type !== Comment)) !== -1;
+    return result;
+  },
   hasIcon() {
     const result = (this.success || this.hasForwardButton);
     return result;
   },
   hasMetaText() {
-    const result = (this.metaText || this.$slots.customMetaText);
+    const result = (this.metaText || (this.$slots.customMetaText && this.$slots.customMetaText().findIndex((node) => (node.type !== Comment)) !== -1));
     return result;
   },
   iconName() {

--- a/src/components/ContentItem/ContentItem.vue
+++ b/src/components/ContentItem/ContentItem.vue
@@ -7,7 +7,7 @@
       @touchStart="toggleIsPressed"
       @touchEnd="toggleIsPressed"
   >
-    <div v-if="$slots.default"
+    <div v-if="hasDefaultSlot"
          class="media"
          :class="{ 'no-border': noBorder }"
          :data-testid="`${dataTestId}-media-icon`"

--- a/src/components/ListItem/ListItem.js
+++ b/src/components/ListItem/ListItem.js
@@ -54,6 +54,10 @@ const watch = {
 };
 
 const computed = {
+  hasDefaultSlot() {
+    const result = this.$slots.default && this.$slots.default().findIndex((node) => (node.type !== Comment)) !== -1;
+    return result;
+  },
   isRightLabelShowing() {
     const result = (!this.hasToggle && this.rightLabel);
     return result;

--- a/src/components/ListItem/ListItem.vue
+++ b/src/components/ListItem/ListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <li class="list-item" :data-testid="dataTestId">
-    <div v-if="$slots.default"
+    <div v-if="hasDefaultSlot"
          class="media"
          :data-testid="`${dataTestId}-icon`"
     >


### PR DESCRIPTION
## Description
In Vue 3, slots are now methods, so a change of the way to detect it's presence should be done. `v-if` comments are now treated as `Comment` node, so a `slot` with a `v-if` contains element inside, so we should check that every content is not a comment to know if its empty

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
