### PR TITLE
Steps and Step component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,9 +81,7 @@ module.exports = {
     'fp/no-get-set': 'error',
     '@getify/proper-ternary/parens': ['error', { call: false, object: false }],
     '@typescript-eslint/consistent-type-imports': 'error',
-    'vue/multi-word-component-names': ['error', {
-      ignores: ['Button', 'Carousel', 'Checkbox', 'Confetti', 'Heading', 'Infobox', 'Screen', 'Stepper', 'Timeline', 'Wrapper'],
-    }],
+    'vue/multi-word-component-names': 0,
     'vue/no-shared-component-data': 'error',
     'vue/no-side-effects-in-computed-properties': 'error',
     'vue/no-unused-components': 'error',

--- a/.github/workflows/mergepr.yml
+++ b/.github/workflows/mergepr.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     env:
       working-dir: ./

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     env:
       working-dir: ./

--- a/src/components/PhoneNumberField/PhoneNumberField.ts
+++ b/src/components/PhoneNumberField/PhoneNumberField.ts
@@ -8,8 +8,8 @@ import TextParagraph from '../TextParagraph/TextParagraph.vue';
 import { onlyDigitsRegexp, nonDigitRegexp } from '../../lib/regexHelper';
 import libphoneNumberMetadata from '../../../data/libphonenumber-metadata.min.json';
 
-const phoneNumberMetadata = JSON.parse(JSON.stringify(libphoneNumberMetadata)) as MetadataJson;
-const getAvailableCountryCodes = () => getCountries(phoneNumberMetadata);
+const getPhoneNumberMetadata = () => JSON.parse(JSON.stringify(libphoneNumberMetadata)) as MetadataJson;
+const getAvailableCountryCodes = () => getCountries(getPhoneNumberMetadata());
 
 const PhoneNumberField = defineComponent({
   name: 'PhoneNumberField',
@@ -82,13 +82,13 @@ const PhoneNumberField = defineComponent({
     },
     formattedPhoneNumber() {
       if (!(this.inputValue && this.countryCode)) { return ''; }
-      const asYouType = new AsYouType(this.countryCode, phoneNumberMetadata);
+      const asYouType = new AsYouType(this.countryCode, getPhoneNumberMetadata());
       const result = asYouType.input(this.cleanedInputValue);
       return result;
     },
     prefix() {
       if (!this.countryCode) { return; }
-      const result = `+${getCountryCallingCode(this.countryCode, phoneNumberMetadata)}`;
+      const result = `+${getCountryCallingCode(this.countryCode, getPhoneNumberMetadata())}`;
       return result;
     },
     hideCountryCode() {
@@ -118,7 +118,7 @@ const PhoneNumberField = defineComponent({
     },
     isPhoneNumberValid() {
       if (this.maxPhoneNumberLength && (this.cleanedInputValue.length > this.maxPhoneNumberLength)) { return false; }
-      const asYouType = new AsYouType(this.countryCode, phoneNumberMetadata);
+      const asYouType = new AsYouType(this.countryCode, getPhoneNumberMetadata());
       asYouType.input((this.inputValue || ''));
       const result = asYouType.isPossible();
       return result;

--- a/src/components/Steps/Step.vue
+++ b/src/components/Steps/Step.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="step">
+    <div class="step-icon">
+      <slot name="icon">
+        <div class="blue-circle"/>
+      </slot>
+    </div>
+    <slot/>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import '../../styles/colors';
+
+.step {
+  margin: 16px;
+  margin-left: 44px;
+  position: relative;
+  border: 1px solid $black-300;
+  border-radius: 20px;
+  overflow: unset;
+}
+.step-icon {
+  left: -28px;
+  top: 16px;
+  position: absolute;
+  display: block;
+  z-index: 2;
+}
+.blue-circle {
+  height: 12px;
+  width: 12px;
+  border-radius: 50%;
+  background-color: $blue-500;
+}
+</style>

--- a/src/components/Steps/Steps.scss
+++ b/src/components/Steps/Steps.scss
@@ -1,0 +1,66 @@
+@import '../../styles/colors';
+
+.steps-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin: 16px auto;
+}
+
+.steps {
+  width: 100%;
+
+  > :deep(*) {
+    margin: 16px;
+    margin-left: 44px;
+    position: relative;
+    border: 1px solid $black-300;
+    border-radius: 20px;
+
+    &:not(.step)::before {
+      content: "";
+      width: 12px;
+      left: -28px;
+      top: 16px;
+      height: 12px;
+      position: absolute;
+      display: block;
+      border-radius: 50%;
+      background-color: $blue-500;
+      z-index: 2;
+    }
+    &:not(:last-child):not(:first-child)::after {
+      content: "";
+      width: 1px;
+      left: -22px;
+      top: -9px;
+      bottom: -9px;
+      position: absolute;
+      display: block;
+      background-color: $black-300;
+      z-index: 1;
+    }
+    &:first-child::after {
+      content: "";
+      width: 1px;
+      left: -22px;
+      top: 28px;
+      bottom: -9px;
+      position: absolute;
+      display: block;
+      background-color: $black-300;
+      z-index: 1;
+    }
+    &:last-child::after {
+      content: "";
+      width: 1px;
+      left: -22px;
+      top: -9px;
+      bottom: calc(100% - 16px);
+      position: absolute;
+      display: block;
+      background-color: $black-300;
+      z-index: 1;
+    }
+  }
+}

--- a/src/components/Steps/Steps.stories.ts
+++ b/src/components/Steps/Steps.stories.ts
@@ -1,0 +1,136 @@
+import type { Meta, StoryFn } from '@storybook/vue3';
+
+import Steps from './Steps.vue';
+import Screen from '../Screen/Screen.vue';
+import ScrollWrapper from '../ScrollWrapper/ScrollWrapper.vue';
+import RenderString from '../../lib/renderString';
+import { createDeviceDecorator } from '../../lib/storybookHelpers';
+
+const deviceDecorator = createDeviceDecorator('<strong>Steps:</strong>&nbsp;A component that lets the user lists elements');
+
+const StepsStories = {
+  component: Steps,
+  title: 'Components/Steps',
+  decorators: [deviceDecorator],
+  args: {
+    ...deviceDecorator.args,
+    dataTestId: '',
+  },
+  argTypes: {
+    ...deviceDecorator.argTypes,
+    dataTestId: { control: { type: 'text' }, name: 'Data test id' },
+    default: {
+      control: {
+        type: 'text',
+      },
+      table: {
+        type: {
+          summary: null,
+        },
+      },
+    },
+  },
+} as Meta<typeof Steps>;
+
+const defaultExample: StoryFn<typeof Steps> = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  setup() { return { ...args }; },
+  components: {
+    Steps,
+    Screen,
+    ScrollWrapper,
+    RenderString,
+  },
+  computed: {
+    defaultSlot() {
+      return this.default;
+    },
+  },
+  template: `
+  <Screen>
+    <ScrollWrapper>
+      <Steps :data-test-id="dataTestId">
+        <RenderString v-if="defaultSlot" :string="defaultSlot"/>
+      </Steps>
+    </ScrollWrapper>
+  </Screen>
+  `,
+});
+defaultExample.args = {
+  default: `<Step><ContentItem title="Title" meta-text="Description" :has-forward-button="false" /></Step>
+<Step><ContentItem title="Title" meta-text="Description" :has-forward-button="false" /></Step>
+<Step><ContentItem title="Title" meta-text="Description" :has-forward-button="false" /></Step>`,
+};
+defaultExample.parameters = {
+  docs: {
+    source: {
+      code: `
+  <Steps>
+    <Step><ContentItem title="Title" meta-text="Description" :has-forward-button="false" /></Step>
+    <Step><ContentItem title="Title" meta-text="Description" :has-forward-button="false" /></Step>
+    <Step><ContentItem title="Title" meta-text="Description" :has-forward-button="false" /></Step>
+  </Steps>
+      `,
+    },
+  },
+};
+
+const customStepsExample: StoryFn<typeof Steps> = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  setup() { return { ...args }; },
+  components: {
+    Steps,
+    Screen,
+    ScrollWrapper,
+    RenderString,
+  },
+  computed: {
+    defaultSlot() {
+      return this.default;
+    },
+  },
+  template: `
+  <Screen>
+    <ScrollWrapper>
+      <Steps>
+        <RenderString v-if="defaultSlot" :string="defaultSlot"/>
+      </Steps>
+    </ScrollWrapper>
+  </Screen>
+  `,
+});
+customStepsExample.args = {
+  default: `<Step>
+  <template v-slot:icon>
+    <TextParagraph size="xsmall" style="background-color: #fff; width: 12px; text-align: center;">1</TextParagraph>
+  </template>
+  <ContentItem title="Title" meta-text="Description" :has-forward-button="false" />
+</Step>
+<SpecCard title="Title"><TextParagraph>You can add content here...</TextParagraph></SpecCard>
+<Step style="padding: 16px;"><Button>Button</Button></Step>`,
+};
+customStepsExample.parameters = {
+  docs: {
+    source: {
+      code: `
+  <Steps>
+    <Step>
+      <template v-slot:icon>
+        <TextParagraph size="xsmall" style="background-color: #fff; width: 12px; text-align: center;">1</TextParagraph>
+      </template>
+      <ContentItem title="Title" meta-text="Description" :has-forward-button="false" />
+    </Step>
+    <SpecCard title="Title"><TextParagraph>You can add content here...</TextParagraph></SpecCard>
+    <Step><Button style="margin: 16px;">Button</Button></Step>
+  </Steps>
+      `,
+    },
+  },
+};
+
+export {
+  defaultExample,
+  customStepsExample,
+};
+
+export default StepsStories;

--- a/src/components/Steps/Steps.test.ts
+++ b/src/components/Steps/Steps.test.ts
@@ -1,0 +1,11 @@
+import { mount } from '@vue/test-utils';
+
+import Steps from './Steps.vue';
+
+describe('Steps', () => {
+  it('Should show given children', () => {
+    const wrapper = mount(Steps, { slots: { default: '<div /><div />' } });
+    const stepsChildren = wrapper.findAll('[data-testid="steps"] *');
+    expect(stepsChildren.length).toBe(2);
+  });
+});

--- a/src/components/Steps/Steps.ts
+++ b/src/components/Steps/Steps.ts
@@ -1,0 +1,13 @@
+import { defineComponent } from 'vue';
+
+const Steps = defineComponent({
+  name: 'Steps',
+  props: {
+    dataTestId: {
+      type: String,
+      default: 'steps',
+    },
+  },
+});
+
+export default Steps;

--- a/src/components/Steps/Steps.vue
+++ b/src/components/Steps/Steps.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="steps-container" :data-testid="`${dataTestId}-container`">
+    <div class="steps" :data-testid="`${dataTestId}`">
+      <slot/>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" src="./Steps.ts"></script>
+<style lang="scss" scoped src="./Steps.scss"></style>

--- a/src/components/StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator.stories.ts
+++ b/src/components/StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/vue3';
 
 import StorybookMobileDeviceSimulator from './StorybookMobileDeviceSimulator.vue';
-import { getAvailableDevices } from './StorybookMobileDeviceSimulator';
+import { getAvailableDevices } from './StorybookMobileDeviceSimulator.utils';
 import { createScreenDecorator } from '../../lib/storybookHelpers';
 import RenderString from '../../lib/renderString';
 

--- a/src/components/StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator.ts
+++ b/src/components/StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator.ts
@@ -1,93 +1,24 @@
 import type { PropType } from 'vue';
 import { defineComponent } from 'vue';
 
-interface Device {
-  width: string,
-  height: string,
-}
-
-// TODO: Add more devices below (get a list of the most common devices and their resolutions from the Mobile team)
-enum DeviceName {
-  default = 'default',
-  small = 'Small',
-  medium = 'Medium',
-  large = 'Large',
-  extraLarge = 'Extra Large',
-  pixel2 = 'Pixel 2',
-  galaxyS5 = 'Galaxy S5',
-  iphone5 = 'iPhone 5',
-  samsungA30 = 'Samsung A30',
-  samsungA50 = 'Samsung A50',
-  huaweiMate20Lite = 'Huawei Mate 20 Lite',
-}
-
-const getAvailableDevices = () => Object.values(DeviceName);
-
-const deviceNameToResolutionLookup: { [key in DeviceName]: Device } = {
-  [DeviceName.default]: {
-    width: '420px',
-    height: '640px',
-  },
-  [DeviceName.small]: {
-    width: '320px',
-    height: '568px',
-  },
-  [DeviceName.medium]: {
-    width: '360px',
-    height: '640px',
-  },
-  [DeviceName.large]: {
-    width: '360px',
-    height: '780px',
-  },
-  [DeviceName.extraLarge]: {
-    width: '412px',
-    height: '892px',
-  },
-  [DeviceName.pixel2]: {
-    width: '411px',
-    height: '731px',
-  },
-  [DeviceName.galaxyS5]: {
-    width: '360px',
-    height: '640px',
-  },
-  [DeviceName.iphone5]: {
-    width: '320px',
-    height: '568px',
-  },
-  [DeviceName.samsungA30]: {
-    width: '412px',
-    height: '892px',
-  },
-  [DeviceName.samsungA50]: {
-    width: '412px',
-    height: '892px',
-  },
-  [DeviceName.huaweiMate20Lite]: {
-    width: '360px',
-    height: '780px',
-  },
-};
+import type { Device, DeviceName } from './StorybookMobileDeviceSimulator.utils';
+import { deviceNameToResolutionLookup, getAvailableDevices } from './StorybookMobileDeviceSimulator.utils';
 
 const StorybookMobileDeviceSimulator = defineComponent({
   name: 'StorybookMobileDeviceSimulator',
   props: {
     device: {
       type: String as PropType<DeviceName>,
-      default: DeviceName.default,
+      default: getAvailableDevices()[0],
       validator: (value: DeviceName) => getAvailableDevices().includes(value),
     },
   },
   computed: {
     resolution(): Device {
-      const result = (deviceNameToResolutionLookup[this.device] || deviceNameToResolutionLookup[DeviceName.default]);
+      const result = (deviceNameToResolutionLookup[this.device] || deviceNameToResolutionLookup.default);
       return result;
     },
   },
 });
-
-export type { DeviceName };
-export { getAvailableDevices };
 
 export default StorybookMobileDeviceSimulator;

--- a/src/components/StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator.utils.ts
+++ b/src/components/StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator.utils.ts
@@ -1,0 +1,71 @@
+interface Device {
+  width: string,
+  height: string,
+}
+
+// TODO: Add more devices below (get a list of the most common devices and their resolutions from the Mobile team)
+enum DeviceName {
+  default = 'default',
+  small = 'Small',
+  medium = 'Medium',
+  large = 'Large',
+  extraLarge = 'Extra Large',
+  pixel2 = 'Pixel 2',
+  galaxyS5 = 'Galaxy S5',
+  iphone5 = 'iPhone 5',
+  samsungA30 = 'Samsung A30',
+  samsungA50 = 'Samsung A50',
+  huaweiMate20Lite = 'Huawei Mate 20 Lite',
+}
+
+const deviceNameToResolutionLookup: { [key in DeviceName]: Device } = {
+  [DeviceName.default]: {
+    width: '420px',
+    height: '640px',
+  },
+  [DeviceName.small]: {
+    width: '320px',
+    height: '568px',
+  },
+  [DeviceName.medium]: {
+    width: '360px',
+    height: '640px',
+  },
+  [DeviceName.large]: {
+    width: '360px',
+    height: '780px',
+  },
+  [DeviceName.extraLarge]: {
+    width: '412px',
+    height: '892px',
+  },
+  [DeviceName.pixel2]: {
+    width: '411px',
+    height: '731px',
+  },
+  [DeviceName.galaxyS5]: {
+    width: '360px',
+    height: '640px',
+  },
+  [DeviceName.iphone5]: {
+    width: '320px',
+    height: '568px',
+  },
+  [DeviceName.samsungA30]: {
+    width: '412px',
+    height: '892px',
+  },
+  [DeviceName.samsungA50]: {
+    width: '412px',
+    height: '892px',
+  },
+  [DeviceName.huaweiMate20Lite]: {
+    width: '360px',
+    height: '780px',
+  },
+};
+
+const getAvailableDevices = () => Object.values(DeviceName);
+
+export type { Device, DeviceName };
+export { getAvailableDevices, deviceNameToResolutionLookup };

--- a/src/components/TextParagraph/TextParagraph.stories.ts
+++ b/src/components/TextParagraph/TextParagraph.stories.ts
@@ -1,10 +1,14 @@
 import type { Meta, StoryFn } from '@storybook/vue3';
 
 import TextParagraph from './TextParagraph.vue';
-import { availableSizes, availableColors, availableWeights } from './TextParagraph';
+import { getAvailableColors, getAvailableWeights, getAvailableSizes } from './TextParagraph';
 import { capitalizeFirstLetter } from '../../lib/textHelper';
 import { createOptionalDeviceDecorator } from '../../lib/storybookHelpers';
 import RenderString from '../../lib/renderString';
+
+const availableColors = getAvailableColors();
+const availableWeights = getAvailableWeights();
+const availableSizes = getAvailableSizes();
 
 const deviceDecorator = createOptionalDeviceDecorator('<strong>TextParagraph:</strong>&nbsp;A text view that represents a paragraph.');
 

--- a/src/components/TextParagraph/TextParagraph.ts
+++ b/src/components/TextParagraph/TextParagraph.ts
@@ -1,55 +1,61 @@
+import type { PropType } from 'vue';
 import { defineComponent } from 'vue';
 
-const availableWeights = [
-  'bold',
-  'medium',
-  'strong',
-];
+enum TextWeight {
+  'bold' = 'bold',
+  'medium' = 'medium',
+  'strong' = 'strong',
+}
 
-const availableSizes = [
-  'xsmall',
-  'small',
-  'medium',
-  'large',
-  'xl',
-  'xxl',
-  'xxxl',
-];
+const getAvailableWeights = () => Object.keys(TextWeight);
 
-const availableColors = [
-  'black-500',
-  'black-700',
-  'blue-500',
-  'blue-700',
-  'brown-500',
-  'brown-700',
-  'green-500',
-  'green-700',
-  'purple-500',
-  'purple-700',
-  'red-500',
-  'red-700',
-  'yellow-500',
-  'yellow-700',
-];
+enum TextSize {
+  'xsmall' = 'xsmall',
+  'small' = 'small',
+  'medium' = 'medium',
+  'large' = 'large',
+  'xl' = 'xl',
+  'xxl' = 'xxl',
+  'xxxl' = 'xxxl',
+}
+
+const getAvailableSizes = () => Object.keys(TextSize);
+
+enum TextColor {
+  'black-500' = 'black-500',
+  'black-700' = 'black-700',
+  'blue-500' = 'blue-500',
+  'blue-700' = 'blue-700',
+  'brown-500' = 'brown-500',
+  'brown-700' = 'brown-700',
+  'green-500' = 'green-500',
+  'green-700' = 'green-700',
+  'purple-500' = 'purple-500',
+  'purple-700' = 'purple-700',
+  'red-500' = 'red-500',
+  'red-700' = 'red-700',
+  'yellow-500' = 'yellow-500',
+  'yellow-700' = 'yellow-700',
+}
+const getAvailableColors = () => Object.keys(TextColor);
 
 const TextParagraph = defineComponent({
   name: 'TextParagraph',
   props: {
     size: {
-      type: String,
+      type: String as PropType<TextSize>,
       default: '',
-      validator(value: string) { return (!value || availableSizes.includes(value)); },
+      validator: (value: TextSize) => (!value || !!getAvailableSizes().includes(value)),
     },
     color: {
-      type: String,
+      type: String as PropType<TextColor>,
       default: '',
-      validator(value: string) { return (!value || availableColors.includes(value)); },
+      validator: (value: TextColor) => (!value || !!getAvailableColors().includes(value)),
     },
     weight: {
-      type: String,
+      type: String as PropType<TextWeight>,
       default: '',
-      validator(value: string) { return (!value || availableWeights.includes(value)); },
+      validator: (value: TextWeight) => (!value || !!getAvailableWeights().includes(value)),
     },
     dataTestId: {
       type: String,
@@ -58,10 +64,15 @@ const TextParagraph = defineComponent({
   },
 });
 
+export type {
+  TextWeight,
+  TextColor,
+  TextSize,
+};
 export {
-  availableWeights,
-  availableColors,
-  availableSizes,
+  getAvailableWeights,
+  getAvailableColors,
+  getAvailableSizes,
 };
 
 export default TextParagraph;

--- a/src/lib/storybookHelpers.ts
+++ b/src/lib/storybookHelpers.ts
@@ -1,7 +1,7 @@
 import type { StoryFn } from '@storybook/vue3';
 
 import StorybookMobileDeviceSimulator from '../components/StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator.vue';
-import { getAvailableDevices } from '../components/StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator';
+import { getAvailableDevices } from '../components/StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator.utils';
 
 const availableDevices = getAvailableDevices();
 

--- a/src/library.ts
+++ b/src/library.ts
@@ -36,8 +36,10 @@ import SignaturePad from './components/SignaturePad/SignaturePad.vue';
 import SlideButton from './components/SlideButton/SlideButton.vue';
 import SpecCard from './components/SpecCard/SpecCard.vue';
 import Stepper from './components/Stepper/Stepper.vue';
+import Steps from './components/Steps/Steps.vue';
+import Step from './components/Steps/Step.vue';
 import StorybookMobileDeviceSimulator from './components/StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator.vue';
-import { getAvailableDevices as getAvailableSimulatedMobileDevices } from './components/StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator';
+import { getAvailableDevices as getAvailableSimulatedMobileDevices } from './components/StorybookMobileDeviceSimulator/StorybookMobileDeviceSimulator.utils';
 import TextField from './components/TextField/TextField.vue';
 import TextParagraph from './components/TextParagraph/TextParagraph.vue';
 import Timeline from './components/Timeline/Timeline.vue';
@@ -87,6 +89,8 @@ export {
   SlideButton,
   SpecCard,
   Stepper,
+  Steps,
+  Step,
   StorybookMobileDeviceSimulator,
   getAvailableSimulatedMobileDevices,
   TextField,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
     "src/**/*.ts",
     "src/**/*.d.ts",
     "src/**/*.vue",
+    "vite.config.ts",
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Description
Add a simple Steps component that list elements after a dot

Add a Step element that allows the user to customize dot

## Screenshots/Captures
Just Steps: 
<img width="408" alt="imagen" src="https://user-images.githubusercontent.com/1281392/152239621-813266d1-d3c8-4e44-ae7b-e70a235e12da.png">

With custom dot and step elements
<img width="420" alt="imagen" src="https://user-images.githubusercontent.com/1281392/152239706-4f3923fa-36d6-4c63-8202-768dcd246444.png">


## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [x] **MINOR** adds functionality in a backwards-compatible manner.
- [ ] **PATCH** backwards-compatible bug fixes.
