### PR TITLE
Fix PhoneNumberField max length behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "9.6.0",
+  "version": "9.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lana/b2c-mapp-ui",
-      "version": "9.6.0",
+      "version": "9.6.1",
       "license": "ISC",
       "dependencies": {
         "@lana/b2c-mapp-ui-assets": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "9.6.0",
+  "version": "9.6.1",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"

--- a/src/components/PhoneNumberField/PhoneNumberField.ts
+++ b/src/components/PhoneNumberField/PhoneNumberField.ts
@@ -96,6 +96,13 @@ const PhoneNumberField = defineComponent({
       const result = (!this.isFocused && !this.inputValue);
       return result;
     },
+    maxLengthWithExtraCharacters() {
+      const maxLength = this.maxLength || this.lengthHint;
+      if (!maxLength) { return; }
+      const charactersAdded = `${this.formattedPhoneNumber}`.length - `${this.modelValue}`.length;
+      const result = maxLength + charactersAdded;
+      return result;
+    },
   },
   methods: {
     emitUpdateModelValueEvent() {

--- a/src/components/PhoneNumberField/PhoneNumberField.vue
+++ b/src/components/PhoneNumberField/PhoneNumberField.vue
@@ -12,7 +12,7 @@
              :disabled="disabled"
              :readonly="readonly"
              :start-focused="startFocused"
-             :max-length="maxLength"
+             :max-length="maxLengthWithExtraCharacters"
              :length-hint="lengthHint"
              :length-hint-label="lengthHintLabel"
              :data-test-id="dataTestId"


### PR DESCRIPTION
## Description
When `maxLength` or `lenghHint` is set for PhoneNumberField it could cause a bad expected behavior to the user, like avoiding to enter a 9-lenghted phone number. An addition of the maxLength calculation that includes the added characters is set, only when `maxLength` or `lengthHint` is given

## Testing
I added the maxLength or lengthHint on storybook and you can enter values longer than expeceted when formatting is applied

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
