### PR TITLE
Fix empty href on button link behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "9.6.1",
+  "version": "9.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lana/b2c-mapp-ui",
-      "version": "9.6.1",
+      "version": "9.6.2",
       "license": "ISC",
       "dependencies": {
-        "@lana/b2c-mapp-ui-assets": "^5.14.0",
+        "@lana/b2c-mapp-ui-assets": "^5.19.0",
         "libphonenumber-js": "^1.9.47",
         "lodash-es": "^4.17.21",
         "vue": "^3.2.21",
@@ -2894,9 +2894,9 @@
       }
     },
     "node_modules/@lana/b2c-mapp-ui-assets": {
-      "version": "5.14.0",
-      "resolved": "https://npm.pkg.github.com/download/@lana/b2c-mapp-ui-assets/5.14.0/45a2f27cf084cda52b29b10c0d08bcb8efb3d7fce9086a6bd6b4ff6962b24f90",
-      "integrity": "sha512-vPxqibTI6y5oxnJ6hM9S+zdg9hl0C+azD0jqksb6JsSTtnLCaWHAAUhHGp96j8Ta0V6eyVDouzndLy1Tq9B1AQ==",
+      "version": "5.19.0",
+      "resolved": "https://npm.pkg.github.com/download/@lana/b2c-mapp-ui-assets/5.19.0/9dccf9056afa06b9c96b1228bbdc0ec46e8ec339b3deec4a70d6cc47d405d1a4",
+      "integrity": "sha512-fB5Y9cxzCNpGnEsLDjBWc8YdHcTGtSY4bomviJ74eQDNMHOkG0Qtya2zWOEJYdahvcNWHyniBzDfNuKyqqlYtA==",
       "license": "ISC",
       "dependencies": {
         "vue": "^3.2.26"
@@ -27747,9 +27747,9 @@
       }
     },
     "@lana/b2c-mapp-ui-assets": {
-      "version": "5.14.0",
-      "resolved": "https://npm.pkg.github.com/download/@lana/b2c-mapp-ui-assets/5.14.0/45a2f27cf084cda52b29b10c0d08bcb8efb3d7fce9086a6bd6b4ff6962b24f90",
-      "integrity": "sha512-vPxqibTI6y5oxnJ6hM9S+zdg9hl0C+azD0jqksb6JsSTtnLCaWHAAUhHGp96j8Ta0V6eyVDouzndLy1Tq9B1AQ==",
+      "version": "5.19.0",
+      "resolved": "https://npm.pkg.github.com/download/@lana/b2c-mapp-ui-assets/5.19.0/9dccf9056afa06b9c96b1228bbdc0ec46e8ec339b3deec4a70d6cc47d405d1a4",
+      "integrity": "sha512-fB5Y9cxzCNpGnEsLDjBWc8YdHcTGtSY4bomviJ74eQDNMHOkG0Qtya2zWOEJYdahvcNWHyniBzDfNuKyqqlYtA==",
       "requires": {
         "vue": "^3.2.26"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-ui",
-  "version": "9.6.1",
+  "version": "9.6.2",
   "description": "Shared custom libraries for building µapps.",
   "bugs": {
     "url": "https://github.com/lana/b2c-mapp-ui/issues"
@@ -48,7 +48,7 @@
     "dist/*"
   ],
   "dependencies": {
-    "@lana/b2c-mapp-ui-assets": "^5.14.0",
+    "@lana/b2c-mapp-ui-assets": "^5.19.0",
     "libphonenumber-js": "^1.9.47",
     "lodash-es": "^4.17.21",
     "vue": "^3.2.21",

--- a/src/components/Button/Button.stories.ts
+++ b/src/components/Button/Button.stories.ts
@@ -21,7 +21,8 @@ const ButtonStories = {
     dropShadow: false,
     debounce: false,
     debounceDelay: 400,
-    href: '',
+    href: undefined,
+    link: false,
     loadingText: 'Cargando...',
     default: 'Example Button',
   },
@@ -34,6 +35,7 @@ const ButtonStories = {
     debounce: { name: 'Has debounce?', control: 'boolean' },
     debounceDelay: { name: 'Debounce Delay', control: { type: 'number', step: 100 } },
     href: { name: 'href', control: 'text' },
+    link: { name: 'Is link?', control: 'boolean' },
     loadingText: { name: 'Loading Text', control: 'text' },
     default: {
       control: {
@@ -67,6 +69,7 @@ const defaultExample: StoryFn<typeof Button> = (args, { argTypes }) => ({
   <div style="margin: 20px;">
     <Button :type="type"
             :href="href"
+            :link="link"
             :loading="loading"
             :loading-text="loadingText"
             :drop-shadow="dropShadow"

--- a/src/components/Button/Button.ts
+++ b/src/components/Button/Button.ts
@@ -25,7 +25,7 @@ const Button = defineComponent({
     },
     href: {
       type: String,
-      default: '',
+      default: undefined,
     },
     link: Boolean,
     loading: Boolean,


### PR DESCRIPTION
## Description
When href is not set it takes the default value `''` which is not the desired value as it expect to be redirected to the same page.

## Testing
Create a <Button link></Button>, click on them, expect to do nothing

## Checks
- [ ] Requires documentation update
- [ ] Requires lib version update

## Versioning impact
- [ ] **MAJOR** incompatible API changes.
- [ ] **MINOR** adds functionality in a backwards-compatible manner.
- [x] **PATCH** backwards-compatible bug fixes.
